### PR TITLE
subprocess.run заменён на API Pylint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
-from abc import ABC, abstractmethod
-from io import StringIO
 import os
 import sys
+from abc import ABC, abstractmethod
+from io import StringIO
 
 from pylint.lint import pylinter, Run
 from pylint.reporters.text import TextReporter
@@ -19,12 +19,11 @@ class PylintWrapper(Linter):
 		pylint_output = StringIO()
 		reporter = TextReporter(pylint_output)
 		try:
-			runner = Run([file_path, '--score=n', '--disable=bad-indentation,missing-final-newline'],
+			runner = Run(
+				[file_path, '--score=n', '--disable=bad-indentation,missing-final-newline'],
 				reporter=reporter,
 				exit=False
-				)
-			if runner.linter.msg_status & 1:
-				print('Pylint analysis finished with Fatal error (return code 1)')
+			)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
 		return pylint_output.getvalue()


### PR DESCRIPTION
### Описание

Рефакторинг модуля проверки Python-кода: вызов Pylint переписан с использования `subprocess.run` на API.

### Мотивация

Получения большего количества полезной информации

### Сравнение решений
Смена подхода сохранила объем информации в полном объеме:
* Реакции программы на возвращаемый код Fatal Error совпадают, путем идеологической замены returncode на runner.linter.msg_status
* Весь вывод результата работы в stdout идентичен, благодаря перехвату поток с помощью StringIO и репортера TextReporter
* Поток stderr отлавливается через try\except Exception

### Перспективы замены `subprocess.run` на API

Можно заменить репортер TextReporter на CollectingReporter. Тогда на выход будет получен не текст, а список объектов message. Объект massage имеет поля, комбинация которых составляет текстовое представления сообщения. Такой подход позволяет выводить только необходимые части каждого сообщения или сортировать/убирать ненужные сообщения по типу ошибки.

### Как тестировать
`python src/main.py file.py`