### PR TITLE
Добавлена обработка опции `--pylint`

### DIFF
--- a/src/linters/base.py
+++ b/src/linters/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import List, Optional
 
 
 class Linter(ABC):
 	@abstractmethod
-	def run(self, file_path: str):
+	def run(self, file_path: str, options: Optional[List[str]] = None):
 		pass

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -1,9 +1,9 @@
+from typing import List, Optional
+
 from pylint.lint import pylinter, Run
 from pylint.reporters import CollectingReporter
 
 from .base import Linter
-
-from typing import List, Optional
 
 DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
 
@@ -12,12 +12,8 @@ class PylintWrapper(Linter):
 	def run(self, file_path: str, options: Optional[List[str]] = None):
 		pylinter.MANAGER.clear_cache()
 		reporter = CollectingReporter()
-		if options is not None:
-			pylint_options = options
-		else:
-			pylint_options = DEFAULT_OPTIONS
 		try:
-			Run([file_path] + pylint_options, reporter=reporter, exit=False)
+			Run([file_path] + (options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
 		return reporter.messages

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -3,13 +3,21 @@ from pylint.reporters import CollectingReporter
 
 from .base import Linter
 
+from typing import List, Optional
+
+DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
+
 
 class PylintWrapper(Linter):
-	def run(self, file_path: str):
+	def run(self, file_path: str, options: Optional[List[str]] = None):
 		pylinter.MANAGER.clear_cache()
 		reporter = CollectingReporter()
+		if options is not None:
+			pylint_options = options
+		else:
+			pylint_options = DEFAULT_OPTIONS
 		try:
-			Run([file_path, '--score=n', '--disable=bad-indentation,missing-final-newline'], reporter=reporter, exit=False)
+			Run([file_path] + pylint_options, reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
 		return reporter.messages

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 import tempfile
+import shlex
 
 from .github_module import login, get_pull_request_metadata, download_pull_request_files
 from .linters import LinterFactory
@@ -20,8 +21,14 @@ def main():
 		sys.exit(1)
 	args = parser.parse_args()
 	try:
-		if args.severity or args.pylint or args.oclint:
+		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')
+		pylint_options = None
+		if args.pylint:
+			pylint_options = []
+			for opt in shlex.split(args.pylint):
+				if opt:
+					pylint_options.append(opt)
 		g = login(args.token)
 		pr = get_pull_request_metadata(g, args.pr_url)
 		with tempfile.TemporaryDirectory() as tmpdir:
@@ -30,7 +37,7 @@ def main():
 				raise Exception('В PR нет подходящих для анализа файлов')
 			for file_path in all_files:
 				linter = LinterFactory.get_linter(file_path)
-				messages = linter.run(file_path)
+				messages = linter.run(file_path, options=pylint_options)
 				generator = ReportGenerator(
 					show_code_snippet = True,
 					snippet_context_lines = 2,

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,8 @@
 import argparse
 import os
 import sys
-import tempfile
 import shlex
+import tempfile
 
 from .github_module import login, get_pull_request_metadata, download_pull_request_files
 from .linters import LinterFactory


### PR DESCRIPTION
### Описание
Реализована обработка опции `--pylint`, которая позволяет заменять опции Pylint по умолчанию на пользовательские.

### Какое новое поведение?
При передаче опции `--pylint` аргумент разбивается через `shlex.split`, пустые строки фильтруются, и полученный список передаётся в функцию `Run` вместо опций по умолчанию. Если опция `--pylint` не передана, используются прежние опции по умолчанию.

### Как тестировать
Запуск без `--pylint` - должны применяться опции по умолчанию:
```
docker run mse1h2026-helper PULL_REQUEST_URL
```
Запуск с `--pylint` - должны применяться переданные опции:
```
docker run mse1h2026-helper --pylint '--score=n --disable=W' PULL_REQUEST_URL
```
Вывод в обоих случаях должен отличаться.