### PR TITLE
Добавлены флаги для гибкой настройки списка PR

### DIFF
--- a/src/hosting_fetcher/forgejo_fetcher/fetch.py
+++ b/src/hosting_fetcher/forgejo_fetcher/fetch.py
@@ -54,9 +54,6 @@ def get_pull_request_metadata(client, pr_url: str) -> PullRequest:
 	user_id = safe_str(
 		user.get('login_name') or user.get('login') or user.get('username')
 	)
-	print('pr_data:', pr_data, flush=True)
-	print('merge_commit_sha:', pr_data.get('merge_commit_sha'), flush=True)
-	print('base.sha:', pr_data['base'].get('sha'), flush=True)
 	return PullRequest(
 		body=safe_str(pr_data.get('body')),
 		changed_files=changed_files, 
@@ -66,7 +63,7 @@ def get_pull_request_metadata(client, pr_url: str) -> PullRequest:
 		repo_url=f'{client.base_url}/{owner}/{repo_name}',
 		pr_url=safe_str(pr_data.get('html_url'), default=pr_url),
 		labels=labels,
-		merge_commit_sha=pr_data['base'].get('sha'),
+		merge_commit_sha=pr_data['head'].get('sha'),
 		merged=bool(pr_data.get('merged', False)),
 		merged_at=parse_datetime(pr_data.get('merged_at')),
 		number=pr_number,

--- a/src/hosting_fetcher/forgejo_fetcher/fetch.py
+++ b/src/hosting_fetcher/forgejo_fetcher/fetch.py
@@ -54,15 +54,19 @@ def get_pull_request_metadata(client, pr_url: str) -> PullRequest:
 	user_id = safe_str(
 		user.get('login_name') or user.get('login') or user.get('username')
 	)
+	print('pr_data:', pr_data, flush=True)
+	print('merge_commit_sha:', pr_data.get('merge_commit_sha'), flush=True)
+	print('base.sha:', pr_data['base'].get('sha'), flush=True)
 	return PullRequest(
 		body=safe_str(pr_data.get('body')),
 		changed_files=changed_files, 
 		closed_at=parse_datetime(pr_data.get('closed_at')),
 		created_at=parse_datetime(pr_data['created_at']),
 		draft=bool(pr_data.get('draft', False)),
-		html_url=safe_str(pr_data.get('html_url'), default=pr_url),
+		repo_url=f'{client.base_url}/{owner}/{repo_name}',
+		pr_url=safe_str(pr_data.get('html_url'), default=pr_url),
 		labels=labels,
-		merge_commit_sha=pr_data.get('merge_commit_sha'),
+		merge_commit_sha=pr_data['base'].get('sha'),
 		merged=bool(pr_data.get('merged', False)),
 		merged_at=parse_datetime(pr_data.get('merged_at')),
 		number=pr_number,

--- a/src/hosting_fetcher/github_fetcher/fetch.py
+++ b/src/hosting_fetcher/github_fetcher/fetch.py
@@ -51,7 +51,6 @@ def download_pull_request_files(
 	pr_metadata: PullRequest,
 	local_dir: str
 ) -> List[str]:
-	print('github', flush=True)
 	repo = client.get_repo(f'{pr_metadata.org_id}/{pr_metadata.repo_id}')
 	pr = repo.get_pull(pr_metadata.number)
 	downloaded_paths = []

--- a/src/hosting_fetcher/github_fetcher/fetch.py
+++ b/src/hosting_fetcher/github_fetcher/fetch.py
@@ -28,7 +28,8 @@ def get_pull_request_metadata(g: Github, pr_url: str) -> PullRequest:
 		closed_at=pr.closed_at,
 		created_at=pr.created_at,
 		draft=getattr(pr, 'draft', False),
-		html_url=pr.html_url,
+		repo_url=repo.html_url,
+		pr_url=pr.html_url,
 		labels=labels,
 		merge_commit_sha=pr.merge_commit_sha,
 		merged=pr.merged,
@@ -50,6 +51,7 @@ def download_pull_request_files(
 	pr_metadata: PullRequest,
 	local_dir: str
 ) -> List[str]:
+	print('github', flush=True)
 	repo = client.get_repo(f'{pr_metadata.org_id}/{pr_metadata.repo_id}')
 	pr = repo.get_pull(pr_metadata.number)
 	downloaded_paths = []

--- a/src/hosting_fetcher/pull_request.py
+++ b/src/hosting_fetcher/pull_request.py
@@ -14,7 +14,8 @@ class PullRequest:
 	closed_at: Optional[datetime]
 	created_at: datetime
 	draft: bool
-	html_url: str
+	repo_url: str
+	pr_url: str
 	labels: List[str]
 	merge_commit_sha: Optional[str]
 	merged: bool

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -84,14 +84,14 @@ class OCLintWrapper(Linter):
 				end_column=end_col,
 			)
 
-			messages.append(
-				Message(
-					msg_id=msg_id,
-					symbol=symbol,
-					location=location,
-					msg=msg_text,
-					confidence=UNDEFINED,
-				)
-			)
+			message = Message(
+						msg_id=msg_id,
+						symbol=symbol,
+						location=location,
+						msg=msg_text,
+						confidence=UNDEFINED,
+					)
+			message.linter = 'OCLint'
+			messages.append(message)
 
 		return messages

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -1,19 +1,97 @@
-import subprocess
 import json
+import subprocess
+from pathlib import PurePath
+
+from pylint.message import Message
+from pylint.typing import MessageLocationTuple
+from pylint.interfaces import UNDEFINED
 
 from .base import Linter
 
 
 class OCLintWrapper(Linter):
+	def _msg_id_for_priority(self, priority: int) -> str:
+		# Pylint ожидает первую букву из своих типов: F/E/W/C/R/I
+		# Для OCLint удобно транслировать так:
+		if priority == 1:
+			return 'ERROR'
+		if priority == 2:
+			return 'WARNING'
+		return 'REFACTOR'
+
 	def run(self, file_path: str):
-		try:
-			result = subprocess.run(
-				['oclint', '-report-type', 'text', file_path, '--', '-std=c++17', '-Wall'],
-				capture_output=True,
-				text=True
+		result = subprocess.run(
+			[
+				'oclint',
+				'-report-type', 'json',
+				file_path,
+				'--',
+				'-std=c++17',
+				'-Wall',
+				'-Wextra',
+				'-pedantic',
+			],
+			capture_output=True,
+			text=True,
+		)
+
+		if result.returncode not in (0, 1):
+			raise RuntimeError(
+				f'OCLint failed with code {result.returncode}:\n'
+				f'stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}'
 			)
-			if result.stderr:
-				return result.stderr + '\n\n' + result.stdout
-			return result.stdout
-		except Exception as e:
-			return f'OCLint error: {str(e)}'
+
+		raw = result.stdout.strip()
+		if not raw:
+			raise RuntimeError(
+				f'OCLint returned empty stdout.\n'
+				f'stderr:\n{result.stderr}'
+			)
+
+		try:
+			data = json.loads(raw)
+		except json.JSONDecodeError as e:
+			raise RuntimeError(
+				f'Failed to parse OCLint JSON: {e}\n'
+				f'raw stdout:\n{raw}\n\nstderr:\n{result.stderr}'
+			)
+
+		violations = data.get('violation', [])
+		print(f'OCLint violations: {len(violations)}', flush=True)
+
+		messages = []
+
+		for v in violations:
+			path = v.get('path', file_path)
+			start_line = int(v.get('startLine', 0) or 0)
+			start_col = int(v.get('startColumn', 0) or 0)
+			end_line = v.get('endLine')
+			end_col = v.get('endColumn')
+
+			priority = int(v.get('priority', 3) or 3)
+			msg_id = self._msg_id_for_priority(priority)
+			symbol = str(v.get('rule', '')).replace(' ', '_')
+			msg_text = str(v.get('message', ''))
+
+			location = MessageLocationTuple(
+				abspath=path,
+				path=path,
+				module=PurePath(path).stem,
+				obj='',
+				line=start_line,
+				column=start_col,
+				end_line=end_line,
+				end_column=end_col,
+			)
+
+			messages.append(
+				Message(
+					msg_id=msg_id,
+					symbol=symbol,
+					location=location,
+					msg=msg_text,
+					confidence=UNDEFINED,
+				)
+			)
+
+		return messages

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -17,4 +17,6 @@ class PylintWrapper(Linter):
 			Run([file_path] + (pylint_options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
+		for message in reporter.messages:
+			message.linter = 'Pylint'
 		return reporter.messages

--- a/src/main.py
+++ b/src/main.py
@@ -56,8 +56,8 @@ def process_pull_request(g, pr_url):
 				generator = ReportGenerator(
 					show_code_snippet=True,
 					snippet_context_lines=2,
-					github_ref=pr.merge_commit_sha,
-					github_repo_url=pr.repo_url
+					hosting_ref=pr.merge_commit_sha,
+					hosting_repo_url=pr.repo_url
 			)
 			report = generator.generate(messages)
 			print(report)

--- a/src/main.py
+++ b/src/main.py
@@ -45,21 +45,22 @@ def process_pull_request(g, pr_url):
 	pr = get_pull_request_metadata(g, pr_url)
 	with tempfile.TemporaryDirectory() as tmpdir:
 		print("PR: ", pr_url)
-		all_files = download_pull_request_files(pr, tmpdir)
-		if not all_files:
-			print(f'Warning: No suitable files found in PR {pr_url}')
-			return
-		for file_path in all_files:
-			linter = LinterFactory.get_linter(file_path)
-			messages = linter.run(file_path)
-			generator = ReportGenerator(
-				show_code_snippet=True,
-				snippet_context_lines=2,
-				github_ref=pr.head.sha,
-				github_repo_url=pr.base.repo.html_url
-		)
-		report = generator.generate(messages)
-		print(report)
+		with tempfile.TemporaryDirectory() as tmpdir:
+			all_files = download_pull_request_files(g, pr, tmpdir)
+			if not all_files:
+				print(f'Warning: No suitable files found in PR {pr_url}')
+				return
+			for file_path in all_files:
+				linter = LinterFactory.get_linter(file_path)
+				messages = linter.run(file_path)
+				generator = ReportGenerator(
+					show_code_snippet=True,
+					snippet_context_lines=2,
+					github_ref=pr.merge_commit_sha,
+					github_repo_url=pr.repo_url
+			)
+			report = generator.generate(messages)
+			print(report)
 
 def main():
 	parser = argparse.ArgumentParser(

--- a/src/main.py
+++ b/src/main.py
@@ -83,33 +83,6 @@ def main():
 	try:
 		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')
-# <<<<<<< HEAD
-# 		if args.pylint:
-# 			linter_options.pylint_options = []
-# 			for opt in shlex.split(args.pylint):
-# 				if opt:
-# 					pylint_options.append(opt)
-# 		client = login(args.token, args.pr_url)
-# 		pr = get_pull_request_metadata(client, args.pr_url)
-# 		with tempfile.TemporaryDirectory() as tmpdir:
-# 			all_files = download_pull_request_files(client, pr, tmpdir)
-# 			if not all_files:
-# 				raise Exception('В PR нет подходящих для анализа файлов')
-# 			for file_path in all_files:
-# 				linter = LinterFactory.get_linter(file_path)
-# 				messages = linter.run(file_path)
-# 				generator = ReportGenerator(
-# 					show_code_snippet = True,
-# 					snippet_context_lines = 2,
-# 					github_ref=pr.merge_commit_sha,
-# 					github_repo_url=pr.html_url
-# 				)
-# 				if file_path.endswith('.py'):
-# 					report = generator.generate(messages)
-# 					print(report)
-# 				else:
-# 					print(messages)
-# =======
 		if (args.pr_range or args.pr_include or args.pr_exclude) and not args.repo:
 			raise ValueError('Флаги --pr-range, --pr-include, --pr-exclude требуют указания --repo')
 		pr_urls = collect_pr_urls(args)
@@ -118,7 +91,6 @@ def main():
 		for pr_url in pr_urls:
 			g = login(args.token, pr_url)
 			process_pull_request(g, pr_url)
-# >>>>>>> 9827f16 (Добавлены флаги для гибкой настройки списка PR)
 	except Exception as e:
 		print(f'Error: {e}')
 		sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import re
 import sys
 import shlex
 import tempfile
@@ -8,47 +10,87 @@ from .linters import LinterFactory
 from .reports import ReportGenerator
 from .linters import options as linter_options
 
+def parse_pr_range(range_str):
+	match = re.match(r'^(\d+)-(\d+)$', range_str)
+	if not match:
+		raise ValueError(f'Invalid PR range format: {range_str}')
+	start, end = int(match.group(1)), int(match.group(2))
+	if start > end:
+		raise ValueError(f'Invalid PR range: start ({start}) > end ({end})')
+	return list(range(start, end + 1))
+
+def parse_pr_list(list_str):
+	try:
+		return [int(num.strip()) for num in list_str.split(',')]
+	except ValueError:
+		raise ValueError(f'Invalid PR list format: {list_str}')
+
+def collect_pr_urls(args):
+	pr_urls = []
+	pr_urls.extend(args.pr_urls)
+	if args.repo:
+		repo_url = args.repo.rstrip('/')
+		pr_numbers = set()
+		if args.pr_range:
+			pr_numbers.update(parse_pr_range(args.pr_range))
+		if args.pr_include:
+			pr_numbers.update(parse_pr_list(args.pr_include))
+		if args.pr_exclude:
+			excluded = set(parse_pr_list(args.pr_exclude))
+			pr_numbers -= excluded
+		for pr_num in sorted(pr_numbers):
+			pr_urls.append(f'{repo_url}/pull/{pr_num}')
+	return pr_urls
+
+def process_pull_request(g, pr_url):
+	pr = get_pull_request_metadata(g, pr_url)
+	with tempfile.TemporaryDirectory() as tmpdir:
+		print("PR: ", pr_url)
+		all_files = download_pull_request_files(pr, tmpdir)
+		if not all_files:
+			print(f'Warning: No suitable files found in PR {pr_url}')
+			return
+		for file_path in all_files:
+			linter = LinterFactory.get_linter(file_path)
+			messages = linter.run(file_path)
+			generator = ReportGenerator(
+				show_code_snippet=True,
+				snippet_context_lines=2,
+				github_ref=pr.head.sha,
+				github_repo_url=pr.base.repo.html_url
+		)
+		report = generator.generate(messages)
+		print(report)
 
 def main():
-	parser = argparse.ArgumentParser(usage='python main.py [OPTIONS] PULL_REQUEST_URL', description='Helper for linting Pull Requests')
+	parser = argparse.ArgumentParser(
+		usage='python main.py [OPTIONS] [PULL_REQUEST_URL ...]',
+		description='Helper for linting Pull Requests'
+	)
 	parser.add_argument('--token', help='Токен GitHub')
 	parser.add_argument('--severity', choices=['error', 'warning', 'note'], help='Минимальная серьёзность проблемы для вывода')
 	parser.add_argument('--pylint', help='Параметры для линтера Pylint')
 	parser.add_argument('--oclint', help='Параметры для линтера OCLint')
-	parser.add_argument('pr_url', metavar='PULL_REQUEST_URL', help='Ссылка на PR')
+	parser.add_argument('--repo', help='URL репозитория для анализа PR по номерам')
+	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
+	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
+	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 6,42)')
 	if len(sys.argv) == 1:
 		parser.print_help()
 		sys.exit(1)
-	args = parser.parse_args()
+	args, remaining = parser.parse_known_args()
+	args.pr_urls = remaining
 	try:
 		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')
-		if args.pylint:
-			linter_options.pylint_options = []
-			for opt in shlex.split(args.pylint):
-				if opt:
-					linter_options.pylint_options.append(opt)
+		if (args.pr_range or args.pr_include or args.pr_exclude) and not args.repo:
+			raise ValueError('Флаги --pr-range, --pr-include, --pr-exclude требуют указания --repo')
+		pr_urls = collect_pr_urls(args)
+		if not pr_urls:
+			raise ValueError('Не указаны PR для анализа')
 		g = login(args.token)
-		pr = get_pull_request_metadata(g, args.pr_url)
-		with tempfile.TemporaryDirectory() as tmpdir:
-			all_files = download_pull_request_files(pr, tmpdir)
-			if not all_files:
-				raise Exception('В PR нет подходящих для анализа файлов')
-			for file_path in all_files:
-				linter = LinterFactory.get_linter(file_path)
-				messages = linter.run(file_path)
-				generator = ReportGenerator(
-					show_code_snippet = True,
-					snippet_context_lines = 2,
-					github_ref=pr.head.sha,
-					github_repo_url=pr.base.repo.html_url
-				)
-				if file_path.endswith('.py'):
-					report = generator.generate(messages)
-					print(report)
-				else:
-					print(messages)
-
+		for pr_url in pr_urls:
+			process_pull_request(g, pr_url)
 	except Exception as e:
 		print(f'Error: {e}')
 		sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -9,8 +9,15 @@ from .linters import LinterFactory
 from .reports import ReportGenerator
 from .linters import options as linter_options
 
+GITHUB_PR_URL_REGEX = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/\d+/?$')
+FORGEJO_PR_URL_REGEX = re.compile(r'^https?://[^/]+/[^/]+/pulls?/\d+/?$')
+PR_RANGE_REGEX = re.compile(r'^(\d+)-(\d+)$')
+
+def is_valid_pr_url(url: str) -> bool:
+    return bool(GITHUB_PR_URL_REGEX.match(url) or FORGEJO_PR_URL_REGEX.match(url))
+
 def parse_pr_range(range_str):
-	match = re.match(r'^(\d+)-(\d+)$', range_str)
+	match = PR_RANGE_REGEX.match(range_str)
 	if not match:
 		raise ValueError(f'Invalid PR range format: {range_str}')
 	start, end = int(match.group(1)), int(match.group(2))
@@ -80,6 +87,10 @@ def main():
 		sys.exit(1)
 	args, remaining = parser.parse_known_args()
 	args.pr_urls = remaining
+	invalid = [url for url in args.pr_urls if not is_valid_pr_url(url)]
+	if any(not is_valid_pr_url(url) for url in args.pr_urls):
+		raise ValueError(f'Invalid PR URL(s): {", ".join(invalid)}')
+	del invalid
 	try:
 		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')

--- a/src/main.py
+++ b/src/main.py
@@ -72,14 +72,16 @@ def main():
 	parser.add_argument('--pylint', help='Параметры для линтера Pylint')
 	parser.add_argument('--oclint', help='Параметры для линтера OCLint')
 	parser.add_argument('--repo', help='URL репозитория для анализа PR по номерам')
-	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
-	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
-	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 6,42)')
+	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 20-40)')
+	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 19,44)')
+	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 21,39)')
+	parser.add_argument('pr_urls', metavar='PULL_REQUEST_URL', nargs='*', help='Ссылки на PR (должны идти после всех флагов)')
+	
 	if len(sys.argv) == 1:
 		parser.print_help()
 		sys.exit(1)
-	args, remaining = parser.parse_known_args()
-	args.pr_urls = remaining
+	
+	args = parser.parse_args()
 	try:
 		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 import sys
 import shlex
 import tempfile
@@ -8,46 +9,115 @@ from .linters import LinterFactory
 from .reports import ReportGenerator
 from .linters import options as linter_options
 
+def parse_pr_range(range_str):
+	match = re.match(r'^(\d+)-(\d+)$', range_str)
+	if not match:
+		raise ValueError(f'Invalid PR range format: {range_str}')
+	start, end = int(match.group(1)), int(match.group(2))
+	if start > end:
+		raise ValueError(f'Invalid PR range: start ({start}) > end ({end})')
+	return list(range(start, end + 1))
+
+def parse_pr_list(list_str):
+	try:
+		return [int(num.strip()) for num in list_str.split(',')]
+	except ValueError:
+		raise ValueError(f'Invalid PR list format: {list_str}')
+
+def collect_pr_urls(args):
+	pr_urls = []
+	pr_urls.extend(args.pr_urls)
+	if args.repo:
+		repo_url = args.repo.rstrip('/')
+		pr_numbers = set()
+		if args.pr_range:
+			pr_numbers.update(parse_pr_range(args.pr_range))
+		if args.pr_include:
+			pr_numbers.update(parse_pr_list(args.pr_include))
+		if args.pr_exclude:
+			excluded = set(parse_pr_list(args.pr_exclude))
+			pr_numbers -= excluded
+		for pr_num in sorted(pr_numbers):
+			pr_urls.append(f'{repo_url}/pull/{pr_num}')
+	return pr_urls
+
+def process_pull_request(g, pr_url):
+	pr = get_pull_request_metadata(g, pr_url)
+	with tempfile.TemporaryDirectory() as tmpdir:
+		print("PR: ", pr_url)
+		all_files = download_pull_request_files(pr, tmpdir)
+		if not all_files:
+			print(f'Warning: No suitable files found in PR {pr_url}')
+			return
+		for file_path in all_files:
+			linter = LinterFactory.get_linter(file_path)
+			messages = linter.run(file_path)
+			generator = ReportGenerator(
+				show_code_snippet=True,
+				snippet_context_lines=2,
+				github_ref=pr.head.sha,
+				github_repo_url=pr.base.repo.html_url
+		)
+		report = generator.generate(messages)
+		print(report)
 
 def main():
-	parser = argparse.ArgumentParser(usage='python main.py [OPTIONS] PULL_REQUEST_URL', description='Helper for linting Pull Requests')
-	parser.add_argument('--token', help='Токен GitHub')
+	parser = argparse.ArgumentParser(
+		usage='python main.py [OPTIONS] [PULL_REQUEST_URL ...]',
+		description='Helper for linting Pull Requests'
+	)
+	parser.add_argument('--token', help='Токен GitHub или Forgejo')
 	parser.add_argument('--severity', choices=['error', 'warning', 'note'], help='Минимальная серьёзность проблемы для вывода')
 	parser.add_argument('--pylint', help='Параметры для линтера Pylint')
 	parser.add_argument('--oclint', help='Параметры для линтера OCLint')
-	parser.add_argument('pr_url', metavar='PULL_REQUEST_URL', help='Ссылка на PR')
+	parser.add_argument('--repo', help='URL репозитория для анализа PR по номерам')
+	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
+	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
+	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 6,42)')
 	if len(sys.argv) == 1:
 		parser.print_help()
 		sys.exit(1)
-	args = parser.parse_args()
+	args, remaining = parser.parse_known_args()
+	args.pr_urls = remaining
 	try:
 		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')
-		if args.pylint:
-			linter_options.pylint_options = []
-			for opt in shlex.split(args.pylint):
-				if opt:
-					pylint_options.append(opt)
-		client = login(args.token, args.pr_url)
-		pr = get_pull_request_metadata(client, args.pr_url)
-		with tempfile.TemporaryDirectory() as tmpdir:
-			all_files = download_pull_request_files(client, pr, tmpdir)
-			if not all_files:
-				raise Exception('В PR нет подходящих для анализа файлов')
-			for file_path in all_files:
-				linter = LinterFactory.get_linter(file_path)
-				messages = linter.run(file_path)
-				generator = ReportGenerator(
-					show_code_snippet = True,
-					snippet_context_lines = 2,
-					github_ref=pr.merge_commit_sha,
-					github_repo_url=pr.html_url
-				)
-				if file_path.endswith('.py'):
-					report = generator.generate(messages)
-					print(report)
-				else:
-					print(messages)
+# <<<<<<< HEAD
+# 		if args.pylint:
+# 			linter_options.pylint_options = []
+# 			for opt in shlex.split(args.pylint):
+# 				if opt:
+# 					pylint_options.append(opt)
+# 		client = login(args.token, args.pr_url)
+# 		pr = get_pull_request_metadata(client, args.pr_url)
+# 		with tempfile.TemporaryDirectory() as tmpdir:
+# 			all_files = download_pull_request_files(client, pr, tmpdir)
+# 			if not all_files:
+# 				raise Exception('В PR нет подходящих для анализа файлов')
+# 			for file_path in all_files:
+# 				linter = LinterFactory.get_linter(file_path)
+# 				messages = linter.run(file_path)
+# 				generator = ReportGenerator(
+# 					show_code_snippet = True,
+# 					snippet_context_lines = 2,
+# 					github_ref=pr.merge_commit_sha,
+# 					github_repo_url=pr.html_url
+# 				)
+# 				if file_path.endswith('.py'):
+# 					report = generator.generate(messages)
+# 					print(report)
+# 				else:
+# 					print(messages)
+# =======
+		if (args.pr_range or args.pr_include or args.pr_exclude) and not args.repo:
+			raise ValueError('Флаги --pr-range, --pr-include, --pr-exclude требуют указания --repo')
+		pr_urls = collect_pr_urls(args)
+		if not pr_urls:
+			raise ValueError('Не указаны PR для анализа')
+		for pr_url in pr_urls:
+			g = login(args.token, pr_url)
+			process_pull_request(g, pr_url)
+# >>>>>>> 9827f16 (Добавлены флаги для гибкой настройки списка PR)
 	except Exception as e:
 		print(f'Error: {e}')
 		sys.exit(1)

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -11,17 +11,17 @@ class ReportGenerator:
 		self,
 		show_code_snippet: bool = True,
 		snippet_context_lines: int = 2,
-		github_ref: Optional[str] = None,
-		github_repo_url: Optional[str] = None
+		hosting_ref: Optional[str] = None,
+		hosting_repo_url: Optional[str] = None
 	):
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
 
-		self._github_info = None
-		if github_ref and github_repo_url:
-			self._github_info = {
-				'ref': github_ref,
-				'repo_url': github_repo_url.rstrip('/')
+		self._hosting_info = None
+		if hosting_ref and hosting_repo_url:
+			self._hosting_info = {
+				'ref': hosting_ref,
+				'repo_url': hosting_repo_url.rstrip('/')
 			}
 
 	def generate(self, messages: List[Message]) -> str:
@@ -67,24 +67,43 @@ class ReportGenerator:
 			return '/'.join(clean_parts[-2:])
 		return clean_parts[-1] if clean_parts else normalized
 
-	def _make_github_link(self, file_path: str, line: int, column: int) -> str:
-		if not self._github_info:
+	def _extract_repo_path(self, file_path: str) -> str:
+		"""Converts absolute path (/tmp/xxx/src/file.py) to a path inside a repository (src/file.py)"""
+		normalized = file_path.replace('\\', '/')
+		parts = normalized.split('/')
+
+		for i, part in enumerate(parts):
+			if part in self._PATH_MARKERS:
+				return '/'.join(parts[i:])
+
+		return parts[-1]  # fallback: file name
+
+	def _detect_hosting(self, repo_url: str) -> str:
+		return 'github' if 'github.com' in repo_url else 'forgejo'
+
+	def _make_link(self, file_path: str, line: int, column: int) -> str:
+		if not self._hosting_info:
 			return f'{file_path}:{line}:{column}'
 
-		clean_path = file_path.replace('\\', '/').lstrip('/')
-		base = self._github_info['repo_url']
-		ref = self._github_info['ref']
+		clean_path = self._extract_repo_path(file_path)
+
+		base = self._hosting_info['repo_url']
+		ref = self._hosting_info['ref']
 
 		if ref:
-			return f'{base}/blob/{ref}/{file_path}#L{line}'
+			hosting = self._detect_hosting(base)
+			if hosting == 'github':
+				return f'{base}/blob/{ref}/{clean_path}#L{line}'
+			else:
+				return f'{base}/src/commit/{ref}/{clean_path}#L{line}'
 		return f'{base}/pull/files'
 
 	def _format_message(self, msg: Message, display_path: str) -> str:
-		github_link = self._make_github_link(display_path, msg.line, msg.column)
+		hosting_link = self._make_link(msg.abspath, msg.line, msg.column)
 
 		first_line = '[Pylint]'
 		second_line = f'{display_path}:{msg.line}: {msg.msg_id}: {msg.msg}'
-		third_line = f'{github_link}'
+		third_line = f'{hosting_link}'
 
 		lines = [first_line, second_line, third_line]
 

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -1,7 +1,10 @@
+import re
 from pathlib import PurePath
 from typing import List, Optional
 
 from pylint.message import Message
+
+TMP_PREFIX = re.compile(r'^/tmp/tmp[^/]+/')
 
 
 class ReportGenerator:
@@ -26,7 +29,7 @@ class ReportGenerator:
 
 	def generate(self, messages: List[Message]) -> str:
 		if not messages:
-			return 'No issues found by Pylint.\n'
+			return 'No issues found.\n'
 
 		messages_by_file = self._group_by_file(messages)
 		lines = []
@@ -54,18 +57,9 @@ class ReportGenerator:
 	def _format_path(self, path: str) -> str:
 		if not path:
 			return path
-
-		normalized = str(PurePath(path)).replace('\\', '/')
-		parts = normalized.split('/')
-
-		for i, part in enumerate(parts):
-			if part in self._PATH_MARKERS and i + 1 < len(parts):
-				return '/'.join(parts[i:]).lstrip('/')
-
-		clean_parts = [p for p in parts if p]
-		if len(clean_parts) >= 2:
-			return '/'.join(clean_parts[-2:])
-		return clean_parts[-1] if clean_parts else normalized
+		path = path.replace('\\', '/')
+		path = TMP_PREFIX.sub('', path)
+		return path.lstrip('/')
 
 	def _extract_repo_path(self, file_path: str) -> str:
 		"""Converts absolute path (/tmp/xxx/src/file.py) to a path inside a repository (src/file.py)"""
@@ -99,9 +93,10 @@ class ReportGenerator:
 		return f'{base}/pull/files'
 
 	def _format_message(self, msg: Message, display_path: str) -> str:
+		linter = getattr(msg, 'linter', 'Unknown linter')
 		hosting_link = self._make_link(msg.abspath, msg.line, msg.column)
 
-		first_line = '[Pylint]'
+		first_line = f'[{linter}]'
 		second_line = f'{display_path}:{msg.line}: {msg.msg_id}: {msg.msg}'
 		third_line = f'{hosting_link}'
 

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -76,7 +76,7 @@ class ReportGenerator:
 		ref = self._github_info['ref']
 
 		if ref:
-			return f'{base}/blob/{ref}/{clean_path}#L{line}'
+			return f'{base}/blob/{ref}/{file_path}#L{line}'
 		return f'{base}/pull/files'
 
 	def _format_message(self, msg: Message, display_path: str) -> str:


### PR DESCRIPTION
Добавлены флаги для настройки проверки PR для конкретного репозитория: --repo и к нему: --pr-range, --pr-include, --pr-exclude соответственно. Все нераспознанные флаги определяются как PR_URL - ссылка на отдельный PR для возможности не соблюдать порядок расстановки

### Описание:
#### Логика обработки флагов вынесена в отдельные функции
<br>

### Какое новое поведение?
#### Можно задать флаги и гибко настраивать список проверяемых PR
<br>

### Как тестировать
```
docker run helper https://github.com/moevm/mse1h2026-helper/pull/24 --repo https://github.com/Piankov-Michail/MathLogicChat --token <your_token> --pr-range 1-6 --pr-exclude 4,5 https://github.com/moevm/mse1h2026-helper/pull/30
```