### PR TITLE
Исправлен анализ OCLint

### DIFF
--- a/src/linters/base.py
+++ b/src/linters/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List
 
 
 class Linter(ABC):

--- a/src/linters/base.py
+++ b/src/linters/base.py
@@ -4,5 +4,5 @@ from typing import List, Optional
 
 class Linter(ABC):
 	@abstractmethod
-	def run(self, file_path: str, options: Optional[List[str]] = None):
+	def run(self, file_path: str):
 		pass

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -8,7 +8,7 @@ class OCLintWrapper(Linter):
 	def run(self, file_path: str):
 		try:
 			result = subprocess.run(
-				['oclint','-report-type', 'text', file_path, '--', '-std=c++17', '-Wall'],
+				['oclint', '-report-type', 'text', file_path, '--', '-std=c++17', '-Wall'],
 				capture_output=True,
 				text=True
 			)

--- a/src/linters/options.py
+++ b/src/linters/options.py
@@ -1,2 +1,1 @@
 pylint_options = None
-oclint_options = None

--- a/src/linters/options.py
+++ b/src/linters/options.py
@@ -1,0 +1,2 @@
+pylint_options = None
+oclint_options = None

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -4,14 +4,16 @@ from pylint.lint import pylinter, Run
 from pylint.reporters import CollectingReporter
 
 from .base import Linter
+from . import options as linter_options
 
 DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
 
 
 class PylintWrapper(Linter):
-	def run(self, file_path: str, options: Optional[List[str]] = None):
+	def run(self, file_path: str):
 		pylinter.MANAGER.clear_cache()
 		reporter = CollectingReporter()
+		options = linter_options.pylint_options
 		try:
 			Run([file_path] + (options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -4,7 +4,7 @@ from pylint.lint import pylinter, Run
 from pylint.reporters import CollectingReporter
 
 from .base import Linter
-from . import options as linter_options
+from .options import pylint_options
 
 DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
 
@@ -13,9 +13,8 @@ class PylintWrapper(Linter):
 	def run(self, file_path: str):
 		pylinter.MANAGER.clear_cache()
 		reporter = CollectingReporter()
-		options = linter_options.pylint_options
 		try:
-			Run([file_path] + (options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
+			Run([file_path] + (pylint_options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
 		return reporter.messages

--- a/src/main.py
+++ b/src/main.py
@@ -21,15 +21,13 @@ def main():
 		sys.exit(1)
 	args = parser.parse_args()
 	try:
-		if args.severity:
+		if args.severity or args.oclint:
 			raise NotImplementedError('Функциональность ещё не реализована')
 		if args.pylint:
 			linter_options.pylint_options = []
 			for opt in shlex.split(args.pylint):
 				if opt:
 					linter_options.pylint_options.append(opt)
-		if args.oclint:
-			raise NotImplementedError('Функциональность ещё не реализована')		
 		g = login(args.token)
 		pr = get_pull_request_metadata(g, args.pr_url)
 		with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import tempfile
 from .github_module import login, get_pull_request_metadata, download_pull_request_files
 from .linters import LinterFactory
 from .reports import ReportGenerator
+from .linters import options as linter_options
 
 
 def main():
@@ -20,14 +21,15 @@ def main():
 		sys.exit(1)
 	args = parser.parse_args()
 	try:
-		if args.severity or args.oclint:
+		if args.severity:
 			raise NotImplementedError('Функциональность ещё не реализована')
-		pylint_options = None
 		if args.pylint:
-			pylint_options = []
+			linter_options.pylint_options = []
 			for opt in shlex.split(args.pylint):
 				if opt:
-					pylint_options.append(opt)
+					linter_options.pylint_options.append(opt)
+		if args.oclint:
+			raise NotImplementedError('Функциональность ещё не реализована')		
 		g = login(args.token)
 		pr = get_pull_request_metadata(g, args.pr_url)
 		with tempfile.TemporaryDirectory() as tmpdir:
@@ -36,7 +38,7 @@ def main():
 				raise Exception('В PR нет подходящих для анализа файлов')
 			for file_path in all_files:
 				linter = LinterFactory.get_linter(file_path)
-				messages = linter.run(file_path, options=pylint_options)
+				messages = linter.run(file_path)
 				generator = ReportGenerator(
 					show_code_snippet = True,
 					snippet_context_lines = 2,


### PR DESCRIPTION
### Описание

Добавлен отдельный файл options.py для хранения глобальных переменных, содержащих опции для pylint и oclint. Необходимость в отдельном файле мотивирована следующим рекурсивным импортом:
```python
#main.py:

from .linters import LinterFactory # Начало рекурсивного импорта
from .reports import ReportGenerator
from .linters import options as linter_options

# Тут могли быть глобальные переменные
```
```python
#factory.py
from .base import Linter
from .pylint_runner import PylintWrapper # Продолжение рекурсивного импорта
from .oclint_runner import OCLintWrapper
from ..config import SUPPORTED_EXTENSIONS

class LinterFactory:
	_linters = {
		'.py': PylintWrapper(),
		**{ext: OCLintWrapper() for ext in SUPPORTED_EXTENSIONS if ext != '.py'}
	}
```
```python
# pylint_runner.py

from pylint.lint import pylinter, Run
from pylint.reporters import CollectingReporter

from .base import Linter
# from . import options as linter_options - Вместо этой строчки было бы
from ..main import pylint_options # Тут было бы зацикливание

DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']


class PylintWrapper(Linter):
	def run(self, file_path: str):
```