### PR TITLE
Добавлен модуль собственных правил

### DIFF
--- a/src/linters/custom_runner.py
+++ b/src/linters/custom_runner.py
@@ -1,8 +1,9 @@
+import json
+import urllib.error
+import urllib.request
 from typing import Any, Callable, List
 from pathlib import PurePath
 from urllib.parse import urlparse
-import urllib.request
-import json
 
 from pylint.message import Message
 from pylint.typing import MessageLocationTuple
@@ -26,7 +27,7 @@ class CustomRulesWrapper(Linter):
 			self._check_commit_size,
 		]
 
-	def run(self, file_path: str = "") -> List[Message]:
+	def run(self, file_path: str = '') -> List[Message]:
 		messages: List[Message] = []
 		ext = PurePath(file_path).suffix
 
@@ -37,20 +38,20 @@ class CustomRulesWrapper(Linter):
 			for rule in self._c_rules:
 				messages.extend(rule(file_path))
 
-		pr = self.context.get("pr")
+		pr = self.context.get('pr')
 		if pr is not None:
 			for rule in self._pr_rules:
 				messages.extend(rule(pr))
 
 		return messages
-	
+
 	def _make_message(self, symbol: str, msg: str,
 		location: MessageLocationTuple | None = None,
 		priority: int = 3) -> Message:
 		if location is None:
 			location = MessageLocationTuple(
-				abspath=".", path=".", module="CUSTOM_RULES",
-				obj="", line=1, column=1, end_line=None, end_column=None,
+				abspath='.', path='.', module='CUSTOM_RULES',
+				obj='', line=1, column=1, end_line=None, end_column=None,
 			)
 
 		msg_id = self._msg_id_for_priority(priority)
@@ -62,7 +63,7 @@ class CustomRulesWrapper(Linter):
 			msg=msg,
 			confidence=UNDEFINED,
 		)
-		message.linter = "CustomRules"
+		message.linter = 'CustomRules'
 		return message
 
 	def _msg_id_for_priority(self, priority: int) -> str:
@@ -74,11 +75,11 @@ class CustomRulesWrapper(Linter):
 
 	def _check_commit_size(self, pr: PullRequest) -> List[Message]:
 		threshold = 5
-		messages = []
+		messages: List[Message] = []
 
 		try:
-			parsed = urlparse(pr.repo_url.rstrip("/"))
-			path_parts = [p for p in parsed.path.split("/") if p]
+			parsed = urlparse(pr.repo_url.rstrip('/'))
+			path_parts = [p for p in parsed.path.split('/') if p]
 			if len(path_parts) < 2:
 				return []
 			owner, repo_name = path_parts[-2], path_parts[-1]
@@ -86,14 +87,17 @@ class CustomRulesWrapper(Linter):
 			return []
 
 		if pr.hosting == 'github':
-			g = self.context.get("github_client")
-			if not g or not pr.commits:
+			g = self.context.get('github_client')
+			if not g:
 				return []
 
 			try:
-				repo = g.get_repo(f"{owner}/{repo_name}")
+				repo = g.get_repo(f'{owner}/{repo_name}')
 			except Exception as e:
-				print(f"[CustomRules] GitHub repo error: {e}")
+				print(f'[CustomRules] GitHub repo error: {e}')
+				return []
+
+			if not pr.commits:
 				return []
 
 			for sha in pr.commits:
@@ -107,54 +111,68 @@ class CustomRulesWrapper(Linter):
 					)
 
 					if total_lines > threshold:
-						messages.append(self._make_message(
-							symbol="large_commit_size",
-							msg=f"Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})",
+						message = self._make_message(
+							symbol='large_commit_size',
+							msg=f'Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})',
 							priority=2,
 							location=MessageLocationTuple(
-								abspath=".", path=".", module=f"COMMIT_{sha[:8]}",
-								obj="", line=1, column=1, end_line=None, end_column=None,
+								abspath='.', path='.', module=f'COMMIT {sha[:8]}',
+								obj='', line=1, column=1, end_line=None, end_column=None,
 							)
-						))
+						)
+						message.specified_commit = sha
+						messages.append(message)
 				except Exception as e:
-					print(f"[CustomRules] GitHub commit {sha} error: {e}")
+					print(f'[CustomRules] GitHub commit {sha} error: {e}')
 
 		elif pr.hosting == 'forgejo':
-			if not pr.commits:
+			pr_index = getattr(pr, 'index', None) or getattr(pr, 'number', None)
+			if pr_index is None:
 				return []
 
-			api_base = f"{parsed.scheme}://{parsed.netloc}/api/v1"
-			token = self.context.get("forgejo_token")
+			api_base = f'{parsed.scheme}://{parsed.netloc}/api/v1'
+			token = self.context.get('forgejo_token')
 
-			for sha in pr.commits:
+			url = f'{api_base}/repos/{owner}/{repo_name}/pulls/{pr_index}/commits'
+			req = urllib.request.Request(url)
+			req.add_header('Accept', 'application/json')
+			if token:
+				req.add_header('Authorization', f'token {token}')
+
+			try:
+				with urllib.request.urlopen(req, timeout=10) as resp:
+					commits = json.loads(resp.read().decode('utf-8'))
+			except urllib.error.HTTPError as e:
+				print(f'[CustomRules] Forgejo PR commits error: {e}')
+				return []
+			except Exception as e:
+				print(f'[CustomRules] Forgejo PR commits parse error: {e}')
+				return []
+
+			for commit_info in commits:
+				sha = commit_info.get('sha') or commit_info.get('id')
+				if not sha:
+					continue
+
 				try:
-					url = f"{api_base}/repos/{owner}/{repo_name}/commits/{sha}"
-					
-					req = urllib.request.Request(url)
-					req.add_header("Accept", "application/json")
-					if token:
-						req.add_header("Authorization", f"token {token}")
-					
-					with urllib.request.urlopen(req, timeout=10) as resp:
-						data = json.loads(resp.read().decode('utf-8'))
-
-					stats = data.get('stats', {})
-					total_lines = (
-						stats.get('total') or
-						(stats.get('additions', 0) + stats.get('deletions', 0))
+					stats = commit_info.get('stats', {})
+					total_lines = stats.get('total') or (
+						stats.get('additions', 0) + stats.get('deletions', 0)
 					)
 
 					if total_lines > threshold:
-						messages.append(self._make_message(
-							symbol="large_commit_size",
-							msg=f"Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})",
+						message = self._make_message(
+							symbol='large_commit_size',
+							msg=f'Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})',
 							priority=2,
 							location=MessageLocationTuple(
-								abspath=".", path=".", module=f"COMMIT_{sha[:8]}",
-								obj="", line=1, column=1, end_line=None, end_column=None,
+								abspath='.', path='.', module=f'COMMIT {sha[:8]}',
+								obj='', line=1, column=1, end_line=None, end_column=None,
 							)
-						))
+						)
+						message.specified_commit = sha
+						messages.append(message)
 				except Exception as e:
-					print(f"[CustomRules] Forgejo error for {sha}: {e}")
+					print(f'[CustomRules] Forgejo commit {sha} error: {e}')
 
 		return messages

--- a/src/linters/custom_runner.py
+++ b/src/linters/custom_runner.py
@@ -76,7 +76,6 @@ class CustomRulesWrapper(Linter):
 		threshold = 5
 		messages = []
 
-		# Извлекаем owner/repo из repo_url
 		try:
 			parsed = urlparse(pr.repo_url.rstrip("/"))
 			path_parts = [p for p in parsed.path.split("/") if p]

--- a/src/linters/custom_runner.py
+++ b/src/linters/custom_runner.py
@@ -1,0 +1,161 @@
+from typing import Any, Callable, List
+from pathlib import PurePath
+from urllib.parse import urlparse
+import urllib.request
+import json
+
+from pylint.message import Message
+from pylint.typing import MessageLocationTuple
+from pylint.interfaces import UNDEFINED
+
+from .base import Linter
+from ..config import SUPPORTED_EXTENSIONS
+from ..hosting_fetcher.pull_request import PullRequest
+
+
+PYTHON_EXT = {'.py'}
+C_EXT = {ext for ext in SUPPORTED_EXTENSIONS if ext != '.py'}
+
+
+class CustomRulesWrapper(Linter):
+	def __init__(self, context: dict[str, Any] | None = None):
+		self.context = context or {}
+		self._py_rules: List[Callable[[str], List[Message]]] = []
+		self._c_rules: List[Callable[[str], List[Message]]] = []
+		self._pr_rules: List[Callable[[PullRequest], List[Message]]] = [
+			self._check_commit_size,
+		]
+
+	def run(self, file_path: str = "") -> List[Message]:
+		messages: List[Message] = []
+		ext = PurePath(file_path).suffix
+
+		if ext in PYTHON_EXT:
+			for rule in self._py_rules:
+				messages.extend(rule(file_path))
+		elif ext in C_EXT:
+			for rule in self._c_rules:
+				messages.extend(rule(file_path))
+
+		pr = self.context.get("pr")
+		if pr is not None:
+			for rule in self._pr_rules:
+				messages.extend(rule(pr))
+
+		return messages
+	
+	def _make_message(self, symbol: str, msg: str,
+		location: MessageLocationTuple | None = None,
+		priority: int = 3) -> Message:
+		if location is None:
+			location = MessageLocationTuple(
+				abspath=".", path=".", module="CUSTOM_RULES",
+				obj="", line=1, column=1, end_line=None, end_column=None,
+			)
+
+		msg_id = self._msg_id_for_priority(priority)
+
+		message = Message(
+			msg_id=msg_id,
+			symbol=symbol,
+			location=location,
+			msg=msg,
+			confidence=UNDEFINED,
+		)
+		message.linter = "CustomRules"
+		return message
+
+	def _msg_id_for_priority(self, priority: int) -> str:
+		if priority == 1:
+			return 'ERROR'
+		if priority == 2:
+			return 'WARNING'
+		return 'REFACTOR'
+
+	def _check_commit_size(self, pr: PullRequest) -> List[Message]:
+		threshold = 5
+		messages = []
+
+		# Извлекаем owner/repo из repo_url
+		try:
+			parsed = urlparse(pr.repo_url.rstrip("/"))
+			path_parts = [p for p in parsed.path.split("/") if p]
+			if len(path_parts) < 2:
+				return []
+			owner, repo_name = path_parts[-2], path_parts[-1]
+		except Exception:
+			return []
+
+		if pr.hosting == 'github':
+			g = self.context.get("github_client")
+			if not g or not pr.commits:
+				return []
+
+			try:
+				repo = g.get_repo(f"{owner}/{repo_name}")
+			except Exception as e:
+				print(f"[CustomRules] GitHub repo error: {e}")
+				return []
+
+			for sha in pr.commits:
+				try:
+					commit = repo.get_commit(sha)
+					stats = commit.stats
+					total_lines = (
+						(stats.total if stats else 0) or
+						((stats.additions or 0) + (stats.deletions or 0))
+						if stats else 0
+					)
+
+					if total_lines > threshold:
+						messages.append(self._make_message(
+							symbol="large_commit_size",
+							msg=f"Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})",
+							priority=2,
+							location=MessageLocationTuple(
+								abspath=".", path=".", module=f"COMMIT_{sha[:8]}",
+								obj="", line=1, column=1, end_line=None, end_column=None,
+							)
+						))
+				except Exception as e:
+					print(f"[CustomRules] GitHub commit {sha} error: {e}")
+
+		elif pr.hosting == 'forgejo':
+			if not pr.commits:
+				return []
+
+			api_base = f"{parsed.scheme}://{parsed.netloc}/api/v1"
+			token = self.context.get("forgejo_token")
+
+			for sha in pr.commits:
+				try:
+					url = f"{api_base}/repos/{owner}/{repo_name}/commits/{sha}"
+					
+					req = urllib.request.Request(url)
+					req.add_header("Accept", "application/json")
+					if token:
+						req.add_header("Authorization", f"token {token}")
+					
+					with urllib.request.urlopen(req, timeout=10) as resp:
+						data = json.loads(resp.read().decode('utf-8'))
+
+					stats = data.get('stats', {})
+					total_lines = (
+						stats.get('total') or
+						(stats.get('additions', 0) + stats.get('deletions', 0))
+					)
+
+					if total_lines > threshold:
+						messages.append(self._make_message(
+							symbol="large_commit_size",
+							msg=f"Коммит {sha[:8]}: {total_lines} строк (лимит: {threshold})",
+							priority=2,
+							location=MessageLocationTuple(
+								abspath=".", path=".", module=f"COMMIT_{sha[:8]}",
+								obj="", line=1, column=1, end_line=None, end_column=None,
+							)
+						))
+				except Exception as e:
+					print(f"[CustomRules] Forgejo error for {sha}: {e}")
+
+		return messages

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ import re
 import sys
 import shlex
 import tempfile
-import os
 
 from .hosting_fetcher import login, get_pull_request_metadata, download_pull_request_files
 from .linters import LinterFactory
@@ -50,7 +49,7 @@ def collect_pr_urls(args):
 			pr_urls.append(f'{repo_url}/pull/{pr_num}')
 	return pr_urls
 
-def process_pull_request(g, pr_url):
+def process_pull_request(g, token, pr_url):
 	pr = get_pull_request_metadata(g, pr_url)
 	with tempfile.TemporaryDirectory() as tmpdir:
 		print('PR: ', pr_url)
@@ -69,9 +68,7 @@ def process_pull_request(g, pr_url):
 		if pr.hosting == 'github':
 			context['github_client'] = g
 		elif pr.hosting == 'forgejo':
-			token = os.getenv('FORGEJO_TOKEN')
-			if token:
-				context['forgejo_token'] = token
+			context['forgejo_token'] = token
 
 		custom_linter = CustomRulesWrapper(context=context)
 		all_messages.extend(custom_linter.run(file_path=''))
@@ -119,7 +116,7 @@ def main():
 			if i > 0:
 				print('\n====================================\n')
 			g = login(args.token, pr_url)
-			process_pull_request(g, pr_url)
+			process_pull_request(g, args.token, pr_url)
 	except Exception as e:
 		print(f'Error: {e}')
 		sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -53,7 +53,7 @@ def collect_pr_urls(args):
 def process_pull_request(g, pr_url):
 	pr = get_pull_request_metadata(g, pr_url)
 	with tempfile.TemporaryDirectory() as tmpdir:
-		print("PR: ", pr_url)
+		print('PR: ', pr_url)
 		all_files = download_pull_request_files(g, pr, tmpdir)
 		if not all_files:
 			print(f'Warning: No suitable files found in PR {pr_url}')
@@ -65,16 +65,16 @@ def process_pull_request(g, pr_url):
 			linter = LinterFactory.get_linter(file_path)
 			all_messages.extend(linter.run(file_path))
 
-		context = {"pr": pr}
+		context = {'pr': pr}
 		if pr.hosting == 'github':
-			context["github_client"] = g
+			context['github_client'] = g
 		elif pr.hosting == 'forgejo':
-			token = os.getenv("FORGEJO_TOKEN")
+			token = os.getenv('FORGEJO_TOKEN')
 			if token:
-				context["forgejo_token"] = token
+				context['forgejo_token'] = token
 
 		custom_linter = CustomRulesWrapper(context=context)
-		all_messages.extend(custom_linter.run(file_path=""))
+		all_messages.extend(custom_linter.run(file_path=''))
 
 		generator = ReportGenerator(
 			show_code_snippet=True,
@@ -115,7 +115,9 @@ def main():
 		pr_urls = collect_pr_urls(args)
 		if not pr_urls:
 			raise ValueError('Не указаны PR для анализа')
-		for pr_url in pr_urls:
+		for i, pr_url in enumerate(pr_urls):
+			if i > 0:
+				print('\n====================================\n')
 			g = login(args.token, pr_url)
 			process_pull_request(g, pr_url)
 	except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -3,10 +3,12 @@ import re
 import sys
 import shlex
 import tempfile
+import os
 
 from .hosting_fetcher import login, get_pull_request_metadata, download_pull_request_files
 from .linters import LinterFactory
 from .reports import ReportGenerator
+from .linters.custom_runner import CustomRulesWrapper
 from .linters import options as linter_options
 
 GITHUB_PR_URL_REGEX = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/\d+/?$')
@@ -52,22 +54,36 @@ def process_pull_request(g, pr_url):
 	pr = get_pull_request_metadata(g, pr_url)
 	with tempfile.TemporaryDirectory() as tmpdir:
 		print("PR: ", pr_url)
-		with tempfile.TemporaryDirectory() as tmpdir:
-			all_files = download_pull_request_files(g, pr, tmpdir)
-			if not all_files:
-				print(f'Warning: No suitable files found in PR {pr_url}')
-				return
-			for file_path in all_files:
-				linter = LinterFactory.get_linter(file_path)
-				messages = linter.run(file_path)
-				generator = ReportGenerator(
-					show_code_snippet=True,
-					snippet_context_lines=2,
-					hosting_ref=pr.merge_commit_sha,
-					hosting_repo_url=pr.repo_url
-			)
-			report = generator.generate(messages)
-			print(report)
+		all_files = download_pull_request_files(g, pr, tmpdir)
+		if not all_files:
+			print(f'Warning: No suitable files found in PR {pr_url}')
+			return
+
+		all_messages = []
+
+		for file_path in all_files:
+			linter = LinterFactory.get_linter(file_path)
+			all_messages.extend(linter.run(file_path))
+
+		context = {"pr": pr}
+		if pr.hosting == 'github':
+			context["github_client"] = g
+		elif pr.hosting == 'forgejo':
+			token = os.getenv("FORGEJO_TOKEN")
+			if token:
+				context["forgejo_token"] = token
+
+		custom_linter = CustomRulesWrapper(context=context)
+		all_messages.extend(custom_linter.run(file_path=""))
+
+		generator = ReportGenerator(
+			show_code_snippet=True,
+			snippet_context_lines=2,
+			hosting_ref=pr.merge_commit_sha,
+			hosting_repo_url=pr.repo_url
+		)
+		report = generator.generate(all_messages)
+		print(report)
 
 def main():
 	parser = argparse.ArgumentParser(

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -75,17 +75,23 @@ class ReportGenerator:
 	def _detect_hosting(self, repo_url: str) -> str:
 		return 'github' if 'github.com' in repo_url else 'forgejo'
 
-	def _make_link(self, file_path: str, line: int, column: int) -> str:
+	def _make_link(self, msg: Message) -> str:
 		if not self._hosting_info:
 			return f'{file_path}:{line}:{column}'
 
-		clean_path = self._extract_repo_path(file_path)
+		file_path, line, column = msg.abspath, msg.line, msg.column
+		commit_sha = getattr(msg, 'specified_commit', None)
 
-		base = self._hosting_info['repo_url']
-		ref = self._hosting_info['ref']
+		base = self._hosting_info['repo_url'].rstrip('/')
 
-		if ref:
+		if commit_sha:
+			return f'{base}/commit/{commit_sha}'
+
+		clean_path = self._extract_repo_path(file_path).lstrip('/')
+
+		if clean_path:
 			hosting = self._detect_hosting(base)
+			ref = self._hosting_info['ref']
 			if hosting == 'github':
 				return f'{base}/blob/{ref}/{clean_path}#L{line}'
 			else:
@@ -94,13 +100,18 @@ class ReportGenerator:
 
 	def _format_message(self, msg: Message, display_path: str) -> str:
 		linter = getattr(msg, 'linter', 'Unknown linter')
-		hosting_link = self._make_link(msg.abspath, msg.line, msg.column)
+		hosting_link = self._make_link(msg)
 
-		first_line = f'[{linter}]'
-		second_line = f'{display_path}:{msg.line}: {msg.msg_id}: {msg.msg}'
-		third_line = f'{hosting_link}'
+		path = (display_path or '').strip()
+		if path in {'.', ''}:
+			path = getattr(msg, 'module', '') or getattr(msg, 'symbol', '')
 
-		lines = [first_line, second_line, third_line]
+		if path:
+			second_line = f'{path}:{msg.line}: {msg.msg_id}: {msg.msg}'
+		else:
+			second_line = f'{msg.msg_id}: {msg.msg}'
+
+		lines = [f'[{linter}]', second_line, hosting_link]
 
 		if self.show_code_snippet:
 			snippet = self._get_code_snippet(msg.abspath, msg.line)


### PR DESCRIPTION
### Описание
Создан файл модуль ```custom_runner.py```. Класс ```CustomRulesWrapper``` из этого файла хранит список кастомных правил для файлов Python, C и PullRequest, что в будущем позволит просто добавить правило для соответствующей сущности. В методе ```run``` выбирается список правил, по которым будет производится проверка. Сообщения для ```ReportGenerator``` формируется в методе ```_make_message```.
Реализовано первое собственное правило ```_check_commit_size```: поиск больших коммитов. 
Пример работы:
```
docker run mse1h2026-helper https://github.com/pasabanov/mse1h2026-helper-test/pull/1
PR:  https://github.com/pasabanov/mse1h2026-helper-test/pull/1

...

[CustomRules]
.:1: WARNING: Коммит c35fc1cd: 15 строк (лимит: 5)
https://github.com/pasabanov/mse1h2026-helper-test/blob/61b7bea2848c65c9d606f08c66f411c8311fb312/.#L1    
```

Для данного правила необходимо передавать клиент ```GitHub``` или ```token``` для ```Forgejo```. Что немного рушит общий подход.
В будущем необходимо включить ```CustomRulesWrapper``` внести в соответствующую фабрику и сделать ее столь же универсальной, как и классы ```OCLintWrapper``` и ```PylintWrapper```.

