### PR TITLE
Добавлены дополнительные аргументы для фильтрации списка пулл-реквестов

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,25 +34,25 @@ def parse_pr_list(list_str):
 
 def pr_passes_filters(pr, args) -> bool:
 	if args.pr_filter_name and args.pr_filter_name not in pr.title:
-		return False
+		return f'заголовок не содержит подстроку "{args.pr_filter_name}"'
 	
 	if args.pr_filter_date_from:
 		from_date = datetime.strptime(args.pr_filter_date_from, '%d.%m.%Y').date()
 		if pr.created_at.date() < from_date:
-			return False
+			return f'создан раньше {args.pr_filter_date_from}'
 	
 	if args.pr_filter_date_to:
 		to_date = datetime.strptime(args.pr_filter_date_to, '%d.%m.%Y').date()
 		if pr.created_at.date() > to_date:
-			return False
+			return f'создан позже {args.pr_filter_date_to}'
 	
 	if args.pr_filter_labels:
 		required_labels = {label.strip() for label in args.pr_filter_labels.split(',') if label.strip()}
 		pr_labels = set(pr.labels or [])
 		if not required_labels.intersection(pr_labels):
-			return False
+			return f'нет ни одной из указанных меток: {args.pr_filter_labels}'
 	
-	return True
+	return None
 
 def collect_pr_urls(args):
 	pr_urls = []
@@ -136,10 +136,11 @@ def main():
 			if i > 0:
 				print('\n====================================\n')
 			g = login(args.token, pr_url)
-
 			pr = get_pull_request(g, pr_url)
-
-			if not pr_passes_filters(pr, args):
+			
+			skip_reason = pr_passes_filters(pr, args)
+			if skip_reason:
+				print(f'Пропуск PR {pr_url}: {skip_reason}')
 				continue
 
 			process_pull_request(g, args.token, pr)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 import argparse
 import re
 import sys
+from datetime import datetime
+import tempfile
 
 from .hosting_fetcher import login, get_pull_request
 from .linters import LinterFactory
@@ -29,6 +31,28 @@ def parse_pr_list(list_str):
 		return [int(num.strip()) for num in list_str.split(',')]
 	except ValueError:
 		raise ValueError(f'Invalid PR list format: {list_str}')
+
+def pr_passes_filters(pr, args) -> bool:
+	if args.pr_filter_name and args.pr_filter_name not in pr.title:
+		return False
+	
+	if args.pr_filter_date_from:
+		from_date = datetime.strptime(args.pr_filter_date_from, '%d.%m.%Y').date()
+		if pr.created_at.date() < from_date:
+			return False
+	
+	if args.pr_filter_date_to:
+		to_date = datetime.strptime(args.pr_filter_date_to, '%d.%m.%Y').date()
+		if pr.created_at.date() > to_date:
+			return False
+	
+	if args.pr_filter_labels:
+		required_labels = {label.strip() for label in args.pr_filter_labels.split(',') if label.strip()}
+		pr_labels = set(pr.labels or [])
+		if not required_labels.intersection(pr_labels):
+			return False
+	
+	return True
 
 def collect_pr_urls(args):
 	pr_urls = []
@@ -87,6 +111,10 @@ def main():
 	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
 	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
 	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 6,42)')
+	parser.add_argument('--pr-filter-name', help='Фильтр по имени PR (должно содержать строку)')
+	parser.add_argument('--pr-filter-date-from', help='Фильтр по дате: от (формат: DD.MM.YYYY)')
+	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: DD.MM.YYYY)')
+	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (убирает пулл-реквесты, у которых нет хотя бы одной из указанных меток)')
 	if len(sys.argv) == 1:
 		parser.print_help()
 		sys.exit(1)
@@ -108,7 +136,12 @@ def main():
 			if i > 0:
 				print('\n====================================\n')
 			g = login(args.token, pr_url)
+
 			pr = get_pull_request(g, pr_url)
+
+			if not pr_passes_filters(pr, args):
+				continue
+
 			process_pull_request(g, args.token, pr)
 	except Exception as e:
 		print(f'Error: {e}')

--- a/src/main.py
+++ b/src/main.py
@@ -14,8 +14,10 @@ GITHUB_PR_URL_REGEX = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/\d+/?$
 FORGEJO_PR_URL_REGEX = re.compile(r'^https?://[^/]+/[^/]+/[^/]+/pulls?/\d+/?$')
 PR_RANGE_REGEX = re.compile(r'^(\d+)-(\d+)$')
 
+
 def is_valid_pr_url(url: str) -> bool:
 	return bool(GITHUB_PR_URL_REGEX.match(url) or FORGEJO_PR_URL_REGEX.match(url))
+
 
 def parse_pr_range(range_str):
 	match = PR_RANGE_REGEX.match(range_str)
@@ -26,33 +28,30 @@ def parse_pr_range(range_str):
 		raise ValueError(f'Invalid PR range: start ({start}) > end ({end})')
 	return list(range(start, end + 1))
 
+
 def parse_pr_list(list_str):
 	try:
 		return [int(num.strip()) for num in list_str.split(',')]
 	except ValueError:
 		raise ValueError(f'Invalid PR list format: {list_str}')
 
-def pr_passes_filters(pr, args) -> bool:
+
+def check_pr_against_filters(pr, args) -> str | None:
 	if args.pr_filter_name and args.pr_filter_name not in pr.title:
 		return f'заголовок не содержит подстроку "{args.pr_filter_name}"'
-	
 	if args.pr_filter_date_from:
-		from_date = datetime.strptime(args.pr_filter_date_from, '%d.%m.%Y').date()
-		if pr.created_at.date() < from_date:
+		if pr.created_at.date() < args.pr_filter_date_from:
 			return f'создан раньше {args.pr_filter_date_from}'
-	
 	if args.pr_filter_date_to:
-		to_date = datetime.strptime(args.pr_filter_date_to, '%d.%m.%Y').date()
-		if pr.created_at.date() > to_date:
+		if pr.created_at.date() > args.pr_filter_date_to:
 			return f'создан позже {args.pr_filter_date_to}'
-	
 	if args.pr_filter_labels:
 		required_labels = {label.strip() for label in args.pr_filter_labels.split(',') if label.strip()}
 		pr_labels = set(pr.labels or [])
-		if not required_labels.intersection(pr_labels):
+		if not required_labels.issubset(pr_labels):
 			return f'нет ни одной из указанных меток: {args.pr_filter_labels}'
-	
 	return None
+
 
 def collect_pr_urls(args):
 	pr_urls = []
@@ -70,6 +69,7 @@ def collect_pr_urls(args):
 		for pr_num in sorted(pr_numbers):
 			pr_urls.append(f'{repo_url}/pull/{pr_num}')
 	return pr_urls
+
 
 def process_pull_request(g, token, pr):
 	print('PR: ', pr.pr_url)
@@ -98,7 +98,13 @@ def process_pull_request(g, token, pr):
 	report = generator.generate(all_messages)
 	print(report)
 
+
 def main():
+	def parse_date(value):
+		try:
+			return datetime.strptime(value, r'%Y.%m.%d').date()
+		except ValueError:
+			raise argparse.ArgumentTypeError('Дата должна быть в формате YYYY.MM.DD')
 	parser = argparse.ArgumentParser(
 		usage='python main.py [OPTIONS] [PULL_REQUEST_URL ...]',
 		description='Helper for linting Pull Requests'
@@ -111,10 +117,10 @@ def main():
 	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
 	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
 	parser.add_argument('--pr-exclude', help='Список номеров PR для исключения (например, 6,42)')
-	parser.add_argument('--pr-filter-name', help='Фильтр по имени PR (должно содержать строку)')
-	parser.add_argument('--pr-filter-date-from', help='Фильтр по дате: от (формат: DD.MM.YYYY)')
-	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: DD.MM.YYYY)')
-	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (убирает пулл-реквесты, у которых нет хотя бы одной из указанных меток)')
+	parser.add_argument('--pr-filter-name', help='Фильтр по имени PR (должно содержать подстроку)')
+	parser.add_argument('--pr-filter-date-from', help='Фильтр по дате: от (формат: YYYY.MM.DD)', type=parse_date)
+	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: YYYY.MM.DD)', type=parse_date)
+	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (PR должен иметь все указанные метки)')
 	if len(sys.argv) == 1:
 		parser.print_help()
 		sys.exit(1)
@@ -137,8 +143,8 @@ def main():
 				print('\n====================================\n')
 			g = login(args.token, pr_url)
 			pr = get_pull_request(g, pr_url)
-			
-			skip_reason = pr_passes_filters(pr, args)
+
+			skip_reason = check_pr_against_filters(pr, args)
 			if skip_reason:
 				print(f'Пропуск PR {pr_url}: {skip_reason}')
 				continue


### PR DESCRIPTION
### Описание

Добавлены новые аргументы командной строки для фильтрации пулл-реквестов перед их обработкой. 
Добавленные флаги:

* ```--pr-filter-name``` - Оставляет только те PR, в заголовке которых содержится указанная подстрока
* ```--pr-filter-date-from``` - Оставляет только PR, созданные не раньше указанной даты (формат `ДД.ММ.ГГГГ`)
* ```--pr-filter-date-to``` - Оставляет только PR, созданные не позже указанной даты (формат `ДД.ММ.ГГГГ`)
* ```--pr-filter-labels``` - Оставляет только PR, у которых есть все указанные метки (список через запятую)

### Поведение
- Эти флаги не требуют --repo