### PR TITLE
Добавлен класс Message

### DIFF
--- a/src/hosting_fetcher/forgejo_fetcher/fetch.py
+++ b/src/hosting_fetcher/forgejo_fetcher/fetch.py
@@ -35,8 +35,9 @@ def parse_pr_url(pr_url: str) -> tuple[str, str, int]:
 		raise ValueError(f'Не найдена секция pulls/pull в URL: {pr_url}')
 	return owner, repo_name, pr_number
 
+
 def get_pull_request(client, pr_url: str) -> PullRequest:
-	tmpdir = tempfile.mkdtemp(prefix=f"pr_{hash(pr_url)}_")
+	tmpdir = tempfile.mkdtemp(prefix=f'pr_{hash(pr_url)}_')
 	atexit.register(_cleanup_dir, tmpdir)
 	owner, repo_name, pr_number = parse_pr_url(pr_url)
 	url = f'{client.base_url}/api/v1/repos/{owner}/{repo_name}/pulls/{pr_number}'

--- a/src/hosting_fetcher/github_fetcher/fetch.py
+++ b/src/hosting_fetcher/github_fetcher/fetch.py
@@ -15,7 +15,7 @@ def _cleanup_dir(path: str) -> None:
 
 
 def get_pull_request(client: Github, pr_url: str) -> PullRequest:
-	tmpdir = tempfile.mkdtemp(prefix=f"pr_{hash(pr_url)}_")
+	tmpdir = tempfile.mkdtemp(prefix=f'pr_{hash(pr_url)}_')
 	atexit.register(_cleanup_dir, tmpdir)
 	path = pr_url.replace('https://github.com', '').strip('/')
 	parts = path.split('/')

--- a/src/linters/custom_rules/base.py
+++ b/src/linters/custom_rules/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Any
 
-from pylint.message import Message
+from ...reports.message import Message
 
 
 class CustomRule(ABC):

--- a/src/linters/custom_rules/commit_size_rule.py
+++ b/src/linters/custom_rules/commit_size_rule.py
@@ -4,11 +4,11 @@ import urllib.request
 from typing import Any, List
 from urllib.parse import urlparse
 
-from pylint.message import Message
-from pylint.typing import MessageLocationTuple
 from pylint.interfaces import UNDEFINED
 
 from .base import PRRule
+from ...reports.message import Message, MessageLocation
+
 
 
 class CommitSizeRule(PRRule):
@@ -60,12 +60,12 @@ class CommitSizeRule(PRRule):
 							symbol='large_commit_size',
 							msg=f'Коммит {sha[:8]}: {total_lines} строк (лимит: {self.threshold})',
 							priority=2,
-							location=MessageLocationTuple(
+							location=MessageLocation(
 								abspath='.', path='.', module=f'COMMIT {sha[:8]}',
 								obj='', line=1, column=1, end_line=None, end_column=None,
-							)
+							),
+							specified_commit = sha
 						)
-						message.specified_commit = sha
 						messages.append(message)
 				except Exception as e:
 					print(f'[CustomRules] GitHub commit {sha} error: {e}')
@@ -110,12 +110,12 @@ class CommitSizeRule(PRRule):
 							symbol='large_commit_size',
 							msg=f'Коммит {sha[:8]}: {total_lines} строк (лимит: {self.threshold})',
 							priority=2,
-							location=MessageLocationTuple(
+							location=MessageLocation(
 								abspath='.', path='.', module=f'COMMIT {sha[:8]}',
 								obj='', line=1, column=1, end_line=None, end_column=None,
-							)
+							),
+							specified_commit = sha
 						)
-						message.specified_commit = sha
 						messages.append(message)
 				except Exception as e:
 					print(f'[CustomRules] Forgejo commit {sha} error: {e}')
@@ -123,10 +123,10 @@ class CommitSizeRule(PRRule):
 		return messages
 
 	def _make_message(self, symbol: str, msg: str,
-		location: MessageLocationTuple | None = None,
-		priority: int = 3) -> Message:
+		location: MessageLocation | None = None,
+		priority: int = 3, specified_commit: str = None) -> Message:
 		if location is None:
-			location = MessageLocationTuple(
+			location = MessageLocation(
 				abspath='.', path='.', module='CUSTOM_RULES',
 				obj='', line=1, column=1, end_line=None, end_column=None,
 			)
@@ -139,8 +139,9 @@ class CommitSizeRule(PRRule):
 			location=location,
 			msg=msg,
 			confidence=UNDEFINED,
+			linter = 'CustomRules',
+			specified_commit = specified_commit
 		)
-		message.linter = 'CustomRules'
 		return message
 
 	def _msg_id_for_priority(self, priority: int) -> str:

--- a/src/linters/custom_rules/goto_rule.py
+++ b/src/linters/custom_rules/goto_rule.py
@@ -1,13 +1,13 @@
 import clang.cindex
 from pathlib import PurePath
-from pylint.message import Message
-from pylint.typing import MessageLocationTuple
-from pylint.interfaces import UNDEFINED
 from typing import List, Any
+
+from pylint.interfaces import UNDEFINED
 
 from .base import FileRule
 from .ast_cache import ASTCache
 from ...config import CPP_EXTENSIONS
+from ...reports.message import Message, MessageLocation
 
 
 class GotoRule(FileRule):
@@ -41,7 +41,7 @@ class GotoRule(FileRule):
 		return messages
 
 	def _make_message(self, file_path: str, line: int, column: int) -> Message:
-		location = MessageLocationTuple(
+		location = MessageLocation(
 			abspath=file_path,
 			path=file_path,
 			module='',
@@ -58,8 +58,8 @@ class GotoRule(FileRule):
 			location=location,
 			msg=f'Найден оператор goto',
 			confidence=UNDEFINED,
+			linter = 'CustomRules'
 		)
-		message.linter = 'CustomRules'
 		return message
 
 class GotoVisitor:

--- a/src/linters/custom_rules/nested_loops_rule.py
+++ b/src/linters/custom_rules/nested_loops_rule.py
@@ -1,13 +1,14 @@
 import ast
 from pathlib import PurePath
-from pylint.message import Message
-from pylint.typing import MessageLocationTuple
-from pylint.interfaces import UNDEFINED
 from typing import List, Any
+
+from pylint.interfaces import UNDEFINED
 
 from .base import FileRule
 from .ast_cache import ASTCache
+
 from ...config import PYTHON_EXTENSIONS
+from ...reports.message import Message, MessageLocation
 
 class NestedLoopsRule(FileRule):
 	def __init__(self, max_depth: int):
@@ -42,7 +43,7 @@ class NestedLoopsRule(FileRule):
 		return messages
 
 	def _make_message(self, file_path: str, line: int, column: int, depth: int) -> Message:
-		location = MessageLocationTuple(
+		location = MessageLocation(
 			abspath=file_path,
 			path=file_path,
 			module='',
@@ -59,8 +60,8 @@ class NestedLoopsRule(FileRule):
 			location=location,
 			msg=f'Вложенность циклов {depth} превышает максимум {self.max_depth}',
 			confidence=UNDEFINED,
+			linter = 'CustomRules'
 		)
-		message.linter = 'CustomRules'
 		return message
 
 class LoopDepthVisitor(ast.NodeVisitor):

--- a/src/linters/custom_runner.py
+++ b/src/linters/custom_runner.py
@@ -1,8 +1,8 @@
-from pylint.message import Message
 from typing import Any, List
 
 from .base import Linter
 from .custom_rules import RuleFactory
+from ..reports.message import Message
 
 class CustomRulesWrapper(Linter):
 	def __init__(self, context: dict[str, Any] | None = None):

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -2,11 +2,10 @@ import json
 import subprocess
 from pathlib import PurePath
 
-from pylint.message import Message
-from pylint.typing import MessageLocationTuple
 from pylint.interfaces import UNDEFINED
 
 from .base import Linter
+from ..reports.message import Message, MessageLocation
 
 
 class OCLintWrapper(Linter):
@@ -73,7 +72,7 @@ class OCLintWrapper(Linter):
 			symbol = str(v.get('rule', '')).replace(' ', '_')
 			msg_text = str(v.get('message') or v.get('rule') or '')
 
-			location = MessageLocationTuple(
+			location = MessageLocation(
 				abspath=path,
 				path=path,
 				module=PurePath(path).stem,
@@ -85,13 +84,13 @@ class OCLintWrapper(Linter):
 			)
 
 			message = Message(
-						msg_id=msg_id,
-						symbol=symbol,
-						location=location,
-						msg=msg_text,
-						confidence=UNDEFINED,
-					)
-			message.linter = 'OCLint'
+				msg_id=msg_id,
+				symbol=symbol,
+				location=location,
+				msg=msg_text,
+				confidence=UNDEFINED,
+				linter="OCLint"
+			)
 			messages.append(message)
 
 		return messages

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -89,7 +89,7 @@ class OCLintWrapper(Linter):
 				location=location,
 				msg=msg_text,
 				confidence=UNDEFINED,
-				linter="OCLint"
+				linter='OCLint'
 			)
 			messages.append(message)
 

--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import List
 
 from pylint.lint import pylinter, Run
 from pylint.reporters import CollectingReporter
 
 from .base import Linter
 from . import options
+from ..reports.message import Message, MessageLocation
 
 DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
 
@@ -17,6 +18,24 @@ class PylintWrapper(Linter):
 			Run([file_path] + (options.pylint_options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
+		custom_messages: List[Message] = []
 		for message in reporter.messages:
-			message.linter = 'Pylint'
-		return reporter.messages
+			location = MessageLocation(
+				abspath=message.abspath,
+				path=message.path,
+				module=message.module,
+				obj=message.obj,
+				line=message.line,
+				column=message.column,
+				end_line=getattr(message, 'end_line', None),
+				end_column=getattr(message, 'end_column', None),
+			)
+			custom_messages.append(Message(
+				msg_id=message.msg_id,
+				symbol=message.symbol,
+				location=location,
+				msg=message.msg,
+				confidence=message.confidence.name if message.confidence else None,
+				linter='Pylint',
+			))
+		return custom_messages

--- a/src/reports/__init__.py
+++ b/src/reports/__init__.py
@@ -1,1 +1,2 @@
 from .report_generator import ReportGenerator
+from .message import Message, MessageLocation

--- a/src/reports/message.py
+++ b/src/reports/message.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class MessageLocation:
+	abspath: str
+	path: str
+	module: str
+	obj: str = ""
+	line: int = 1
+	column: int = 1
+	end_line: Optional[int] = None
+	end_column: Optional[int] = None
+
+@dataclass
+class Message:
+	msg: str
+	symbol: str
+	location: MessageLocation
+	msg_id: Optional[str] = None
+	confidence: Optional[str] = None
+	linter: Optional[str] = None
+	priority: Optional[int] = None
+	specified_commit: Optional[str] = None
+
+	@property
+	def abspath(self) -> str:
+		return self.location.abspath if self.location else ""
+
+	@property
+	def path(self) -> str:
+		return self.location.path if self.location else ""
+
+	@property
+	def module(self) -> str:
+		return self.location.module if self.location else ""
+
+	@property
+	def line(self) -> int:
+		return self.location.line if self.location else 1
+
+	@property
+	def column(self) -> int:
+		return self.location.column if self.location else 1
+
+	@property
+	def end_line(self) -> Optional[int]:
+		return self.location.end_line if self.location else None
+
+	@property
+	def end_column(self) -> Optional[int]:
+		return self.location.end_column if self.location else None

--- a/src/reports/message.py
+++ b/src/reports/message.py
@@ -7,11 +7,12 @@ class MessageLocation:
 	abspath: str
 	path: str
 	module: str
-	obj: str = ""
-	line: int = 1
-	column: int = 1
+	obj: str = ''
+	line: Optional[int] = None
+	column: Optional[int] = None
 	end_line: Optional[int] = None
 	end_column: Optional[int] = None
+
 
 @dataclass
 class Message:
@@ -26,23 +27,23 @@ class Message:
 
 	@property
 	def abspath(self) -> str:
-		return self.location.abspath if self.location else ""
+		return self.location.abspath if self.location else ''
 
 	@property
 	def path(self) -> str:
-		return self.location.path if self.location else ""
+		return self.location.path if self.location else ''
 
 	@property
 	def module(self) -> str:
-		return self.location.module if self.location else ""
+		return self.location.module if self.location else ''
 
 	@property
 	def line(self) -> int:
-		return self.location.line if self.location else 1
+		return self.location.line if self.location else None
 
 	@property
 	def column(self) -> int:
-		return self.location.column if self.location else 1
+		return self.location.column if self.location else None
 
 	@property
 	def end_line(self) -> Optional[int]:

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from pylint.message import Message
+from .message import Message
 
 TMP_PREFIX = re.compile(r'^/tmp/tmp[^/]+/')
 


### PR DESCRIPTION
### Описание
Заменён `pylint.message.Message` на кастомный унифицированный класс `Message` во всех линтерах и кастомных правилах. Класс находится в файле `src/reports/message.py`. Специфичный для `Pylint` класс `MessageLocationTuple` заменен на собсвтенный аналогичный класс `MessageLocation`, выполняющий ту же роль и хранящийся как поле `Message`.

### Новое поведение
- Все линтеры и правила возвращают единый тип `Message`, поля заполняются строго в конструкторе.
- `ReportGenerator` работает без изменений благодаря обратной совместимости (`@property`-делегаты).