### PR TITLE
Вновь добавлена обработка опции `--pylint`

### DIFF
--- a/src/linters/pylint_runner.py
+++ b/src/linters/pylint_runner.py
@@ -4,7 +4,7 @@ from pylint.lint import pylinter, Run
 from pylint.reporters import CollectingReporter
 
 from .base import Linter
-from .options import pylint_options
+from . import options
 
 DEFAULT_OPTIONS = ['--score=n', '--disable=bad-indentation,missing-final-newline']
 
@@ -14,7 +14,7 @@ class PylintWrapper(Linter):
 		pylinter.MANAGER.clear_cache()
 		reporter = CollectingReporter()
 		try:
-			Run([file_path] + (pylint_options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
+			Run([file_path] + (options.pylint_options or DEFAULT_OPTIONS), reporter=reporter, exit=False)
 		except Exception as e:
 			return f'Pylint API Error: {str(e)}'
 		for message in reporter.messages:

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 import argparse
-import re
-import sys
 from datetime import datetime
+import re
+import shlex
+import sys
 import tempfile
 
 from .hosting_fetcher import login, get_pull_request
@@ -135,6 +136,11 @@ def main():
 			raise NotImplementedError('Функциональность ещё не реализована')
 		if (args.pr_range or args.pr_include or args.pr_exclude) and not args.repo:
 			raise ValueError('Флаги --pr-range, --pr-include, --pr-exclude требуют указания --repo')
+		if args.pylint:
+			linter_options.pylint_options = []
+			for opt in shlex.split(args.pylint):
+				if opt:
+					linter_options.pylint_options.append(opt)
 		pr_urls = collect_pr_urls(args)
 		if not pr_urls:
 			raise ValueError('Не указаны PR для анализа')

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,13 @@
 import argparse
-from datetime import datetime
 import re
 import shlex
 import sys
-import tempfile
+from datetime import datetime
 
-from .hosting_fetcher import login, get_pull_request
-from .linters import LinterFactory
 from .linters.custom_runner import CustomRulesWrapper
+from .linters import LinterFactory
 from .linters import options as linter_options
+from .hosting_fetcher import login, get_pull_request
 from .reports import ReportGenerator
 
 GITHUB_PR_URL_REGEX = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/\d+/?$')


### PR DESCRIPTION
### Описание
Возвращена работа с флагами для `pylint` в `main.py`. При тестировании были обнаружены ошибки отсутствия переданных в программу флагов.

**Причина:** Переменная конфигурации импортировалась по значению `from .options import pylint_options` при инициализации модуля. В результате `PylintWrapper` "видел" только начальное значение `None`, а изменения, внесённые в `main.py` во время парсинга аргументов, до него не доходили.

**Решение:** Выполнен переход на обращение к атрибуту модуля во время выполнения: `from . import options` -> `options.pylint_options`.

### Как тестировать
   ```bash
   PS C:\mse1h2026-helper> docker run mse1h2026-helper --token <> --pylint "--disable=all --enable=E" https://github.com/moevm/mse1h2026-helper/pull/68
   ```
   В результате будут получены только сообщения с маркировкой `E`