### PR TITLE
Добавлен вывод информации о пулл-реквесте и его авторе для каждого пулл-реквеста

### DIFF
--- a/src/hosting_fetcher/forgejo_fetcher/fetch.py
+++ b/src/hosting_fetcher/forgejo_fetcher/fetch.py
@@ -64,6 +64,8 @@ def get_pull_request(client, pr_url: str) -> PullRequest:
 	user_id = safe_str(
 		user.get('login_name') or user.get('login') or user.get('username')
 	)
+	user_login = safe_str(user.get('login_name') or user.get('login') or user.get('username'))
+	user_name = safe_str(user.get('full_name') or user.get('name'))
 	pr_obj = PullRequest(
 		body=safe_str(pr_data.get('body')),
 		changed_files=changed_files,
@@ -85,6 +87,8 @@ def get_pull_request(client, pr_url: str) -> PullRequest:
 		org_id=owner,
 		repo_id=repo_name,
 		user_id=user_id,
+		author_username=user_login,
+		author_name=user_name,
 		files_dir=tmpdir,
 		files=[],
 	)

--- a/src/hosting_fetcher/forgejo_fetcher/fetch.py
+++ b/src/hosting_fetcher/forgejo_fetcher/fetch.py
@@ -61,9 +61,6 @@ def get_pull_request(client, pr_url: str) -> PullRequest:
 		if label.get('name')
 	]
 	user = pr_data.get('user', {}) or {}
-	user_id = safe_str(
-		user.get('login_name') or user.get('login') or user.get('username')
-	)
 	user_login = safe_str(user.get('login_name') or user.get('login') or user.get('username'))
 	user_name = safe_str(user.get('full_name') or user.get('name'))
 	pr_obj = PullRequest(
@@ -86,7 +83,6 @@ def get_pull_request(client, pr_url: str) -> PullRequest:
 		hosting='forgejo',
 		org_id=owner,
 		repo_id=repo_name,
-		user_id=user_id,
 		author_username=user_login,
 		author_name=user_name,
 		files_dir=tmpdir,

--- a/src/hosting_fetcher/github_fetcher/fetch.py
+++ b/src/hosting_fetcher/github_fetcher/fetch.py
@@ -33,6 +33,8 @@ def get_pull_request(client: Github, pr_url: str) -> PullRequest:
 	user_id = safe_str(
 		getattr(pr.user, 'name', None) or getattr(pr.user, 'login', None)
 	)
+	user_login = safe_str(getattr(pr.user, 'login', None))
+	user_name = safe_str(getattr(pr.user, 'name', None))
 	info(f'Найден PR #{pr_number} в репозитории {owner}/{repo_name}')
 	pr_obj = PullRequest(
 		body=safe_str(pr.body),
@@ -55,6 +57,8 @@ def get_pull_request(client: Github, pr_url: str) -> PullRequest:
 		org_id=owner,
 		repo_id=repo_name,
 		user_id=user_id,
+		author_username=user_login,
+		author_name=user_name,
 		files_dir=tmpdir,
 		files=[],
 	)

--- a/src/hosting_fetcher/github_fetcher/fetch.py
+++ b/src/hosting_fetcher/github_fetcher/fetch.py
@@ -30,9 +30,6 @@ def get_pull_request(client: Github, pr_url: str) -> PullRequest:
 	pr = repo.get_pull(pr_number)
 	labels = [label.name for label in pr.get_labels()]
 	commits = [commit.sha for commit in pr.get_commits()]
-	user_id = safe_str(
-		getattr(pr.user, 'name', None) or getattr(pr.user, 'login', None)
-	)
 	user_login = safe_str(getattr(pr.user, 'login', None))
 	user_name = safe_str(getattr(pr.user, 'name', None))
 	info(f'Найден PR #{pr_number} в репозитории {owner}/{repo_name}')
@@ -56,7 +53,6 @@ def get_pull_request(client: Github, pr_url: str) -> PullRequest:
 		hosting='github',
 		org_id=owner,
 		repo_id=repo_name,
-		user_id=user_id,
 		author_username=user_login,
 		author_name=user_name,
 		files_dir=tmpdir,

--- a/src/hosting_fetcher/pull_request.py
+++ b/src/hosting_fetcher/pull_request.py
@@ -31,4 +31,6 @@ class PullRequest:
 	repo_id: str
 	user_id: str
 	files_dir: Path
+	author_username: str = ''
+	author_name: str = ''
 	files: List[Path] = field(default_factory=list)

--- a/src/hosting_fetcher/pull_request.py
+++ b/src/hosting_fetcher/pull_request.py
@@ -29,7 +29,6 @@ class PullRequest:
 	hosting: HostingType
 	org_id: str
 	repo_id: str
-	user_id: str
 	files_dir: Path
 	author_username: str = ''
 	author_name: str = ''

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -149,7 +149,14 @@ class ReportGenerator:
 					print('\n====================================\n')
 				first = False
 
+				author_display = pr.author_username
+				if pr.author_name:
+					author_display = f'{pr.author_username} ({pr.author_name})'
+				date_str = pr.created_at.strftime('%Y.%m.%d') if pr.created_at else 'N/A'
+				print('\nRepository: ', pr.repo_url)
 				print('PR: ', pr.pr_url)
+				print('Author: ', author_display)
+				print('Date: ', date_str)
 
 				if not pr.files:
 					warning(f'Warning: No suitable files found in PR {pr.pr_url}')


### PR DESCRIPTION
### Описание
Добавлен расширенный вывод метаданных PR в начале каждого отчёта. В датакласс `PullRequest` добавлены поля `author_username` и `author_name`, ставшее избыточным поле `user_id` удалено. Fetcher-ы для GitHub и Forgejo обновлены для раздельного сохранения логина и полного имени автора. Полное имя выводится только если оно заполнено, так как в GitHub и Forgejo это необязательное поле профиля.

### Какое новое поведение?
```python
docker run mse1h2026-helper https://github.com/moevm/mse1h2026-helper/pull/81 --token ...
```
Ожидаемый результат:
```python
[23:51:51] Авторизация на GitHub выполнена
[23:51:54] Найден PR #81 в репозитории moevm/mse1h2026-helper
[23:51:57] Загружены файлы: main.py, __init__.py, report_generator.py
[23:51:57] Обработка файла /tmp/pr_4222922319970555289_a5rnvb65/src/main.py (1/3)
[23:51:57] Обработка файла /tmp/pr_4222922319970555289_a5rnvb65/src/reports/__init__.py (2/3)
[23:51:58] Обработка файла /tmp/pr_4222922319970555289_a5rnvb65/src/reports/report_generator.py (3/3)

Repository:  https://github.com/moevm/mse1h2026-helper
PR:  https://github.com/moevm/mse1h2026-helper/pull/81
Author:  bulb0lbul (Prokopovich Yana)
Date:  2026.05.19

...
```