### PR TITLE
Добавлены минимальные разрешения для workflow pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Описание

В файл `.github/workflows/pytest.yml` добавлен блок `permissions` с минимально необходимым разрешением `contents: read`, которое требуется для чтения содержимого репозитория на шаге клонирования кода в среду выполнения. Остальные шаги не взаимодействуют с GitHub API и никаких дополнительных разрешений не требуют. 