### PR TITLE
Добавлена опция сортировки сообщений

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -121,6 +121,7 @@ def main():
 	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: YYYY.MM.DD)', type=parse_date)
 	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (PR должен иметь все указанные метки)')
 	parser.add_argument('--rule-param', action='append', dest='rule_params', default=[], help='Параметры правил в формате rule_name:param1,param2,...')
+	parser.add_argument('--sort-messages', choices=['files', 'severity', 'tools'], default=None, const='files', nargs='?', help='Режим сортировки сообщений: files (по файлам), severity (по серьёзности), tools (по инструментам)')
 	parser.add_argument('-q', '--quiet', action='store_true', help='Отключить отладочные сообщения')
 	if len(sys.argv) == 1:
 		parser.print_help()
@@ -163,7 +164,7 @@ def main():
 
 			results.append((pr, process_pull_request(g, args.token, pr)))
 
-		ReportGenerator().generate(results)
+		ReportGenerator(sort_messages=args.sort_messages).generate(results)
 
 	except Exception as e:
 		error(str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from .linters import options as linter_options
 from .linters.custom_rules import RuleFactory
 from .hosting_fetcher import login, get_pull_request
 from .logger import info, warning, error, set_quiet
-from .reports import ReportGenerator
+from .reports import ReportGenerator, OPTION_SORT_MESSAGES_CHOICES, OPTION_SORT_MESSAGES_DEFAULT
 
 GITHUB_PR_URL_REGEX = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/\d+/?$')
 FORGEJO_PR_URL_REGEX = re.compile(r'^https?://[^/]+/[^/]+/[^/]+/pulls?/\d+/?$')
@@ -121,7 +121,7 @@ def main():
 	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: YYYY.MM.DD)', type=parse_date)
 	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (PR должен иметь все указанные метки)')
 	parser.add_argument('--rule-param', action='append', dest='rule_params', default=[], help='Параметры правил в формате rule_name:param1,param2,...')
-	parser.add_argument('--sort-messages', choices=['files', 'severity', 'tools'], default='files', help='Режим сортировки сообщений: files (по файлам), severity (по серьёзности), tools (по инструментам)')
+	parser.add_argument('--sort-messages', choices=OPTION_SORT_MESSAGES_CHOICES, default=OPTION_SORT_MESSAGES_DEFAULT, help='Режим сортировки сообщений: files (по файлам), severity (по серьёзности), tools (по инструментам)')
 	parser.add_argument('-q', '--quiet', action='store_true', help='Отключить отладочные сообщения')
 	if len(sys.argv) == 1:
 		parser.print_help()

--- a/src/main.py
+++ b/src/main.py
@@ -121,7 +121,7 @@ def main():
 	parser.add_argument('--pr-filter-date-to', help='Фильтр по дате: до (формат: YYYY.MM.DD)', type=parse_date)
 	parser.add_argument('--pr-filter-labels', help='Фильтр по меткам (PR должен иметь все указанные метки)')
 	parser.add_argument('--rule-param', action='append', dest='rule_params', default=[], help='Параметры правил в формате rule_name:param1,param2,...')
-	parser.add_argument('--sort-messages', choices=['files', 'severity', 'tools'], default=None, const='files', nargs='?', help='Режим сортировки сообщений: files (по файлам), severity (по серьёзности), tools (по инструментам)')
+	parser.add_argument('--sort-messages', choices=['files', 'severity', 'tools'], default='files', help='Режим сортировки сообщений: files (по файлам), severity (по серьёзности), tools (по инструментам)')
 	parser.add_argument('-q', '--quiet', action='store_true', help='Отключить отладочные сообщения')
 	if len(sys.argv) == 1:
 		parser.print_help()

--- a/src/main.py
+++ b/src/main.py
@@ -164,7 +164,7 @@ def main():
 
 			results.append((pr, process_pull_request(g, args.token, pr)))
 
-		ReportGenerator(sort_messages=args.sort_messages).generate(results)
+		ReportGenerator(sort_messages=args.sort_messages, first_separator=not args.quiet).generate(results)
 
 	except Exception as e:
 		error(str(e))

--- a/src/reports/__init__.py
+++ b/src/reports/__init__.py
@@ -1,2 +1,2 @@
-from .report_generator import ReportGenerator, PullRequestReportGenerator
+from .report_generator import OPTION_SORT_MESSAGES_CHOICES, OPTION_SORT_MESSAGES_DEFAULT, ReportGenerator, PullRequestReportGenerator
 from .message import Message, MessageLocation

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -8,8 +8,8 @@ from ..logger import warning
 
 TMP_PREFIX = re.compile(r'^/tmp/tmp[^/]+/')
 
-TOOL_RANK = {'Pylint': 0, 'OCLint': 1, 'CustomRules': 2}
-TOOL_LABELS = {0: 'Pylint', 1: 'OCLint', 2: 'CustomRules'}
+TOOL_RANK = {'Pylint': 0, 'OCLint': 1, 'CustomRules': 2, 'Other': 3}
+TOOL_LABELS = {0: 'Pylint', 1: 'OCLint', 2: 'CustomRules', 3: 'Other'}
 SEVERITY_LABELS = {0: 'INFO', 1: 'REFACTOR', 2: 'CONVENTION', 3: 'WARNING', 4: 'ERROR', 5: 'FATAL'}
 
 
@@ -27,7 +27,7 @@ class PullRequestReportGenerator:
 		self.sort_messages = sort_messages
 
 	def _tool_rank(self, msg: Message) -> int:
-		return TOOL_RANK[msg.linter]
+		return TOOL_RANK.get(msg.linter, TOOL_RANK['Other'])
 
 	def _severity_rank(self, msg: Message) -> int:
 		msg_id = (msg.msg_id or '').strip().upper()

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -1,4 +1,5 @@
 import re
+from itertools import groupby
 from pathlib import Path
 from typing import List, Optional
 
@@ -7,44 +8,74 @@ from ..logger import warning
 
 TMP_PREFIX = re.compile(r'^/tmp/tmp[^/]+/')
 
+TOOL_RANK = {'Pylint': 0, 'OCLint': 1, 'CustomRules': 2}
+TOOL_LABELS = {0: 'Pylint', 1: 'OCLint', 2: 'CustomRules'}
+SEVERITY_LABELS = {0: 'INFO', 1: 'REFACTOR', 2: 'CONVENTION', 3: 'WARNING', 4: 'ERROR', 5: 'FATAL'}
+
 
 class PullRequestReportGenerator:
 	def __init__(
 		self,
 		pr,
 		show_code_snippet: bool = True,
-		snippet_context_lines: int = 2
+		snippet_context_lines: int = 2,
+		sort_messages: str | None = None,
 	):
 		self.pr = pr
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
+		self.sort_messages = sort_messages
+
+	def _tool_rank(self, msg: Message) -> int:
+		return TOOL_RANK[msg.linter]
+
+	def _severity_rank(self, msg: Message) -> int:
+		msg_id = (msg.msg_id or '').strip().upper()
+		return {'I': 0, 'R': 1, 'C': 2, 'W': 3, 'E': 4, 'F': 5}.get(msg_id[:1], 0)
+
+	def _display_path(self, msg: Message) -> str:
+		return self._get_repo_relative_path(msg.abspath).lstrip('/')
 
 	def generate(self, messages: List[Message]) -> str:
 		if not messages:
 			return 'No issues found.\n'
 
-		messages_by_file = self._group_by_file(messages)
+		if self.sort_messages is None:
+			lines = []
+			for msg in messages:
+				lines.append(self._format_message(msg, self._display_path(msg)))
+				lines.append('')
+			return '\n'.join(lines)
+
+		mode = self.sort_messages
+
+		if mode == 'files':
+			sort_key = lambda m: (self._display_path(m).lower(), self._tool_rank(m), self._severity_rank(m))
+			group_fn = self._display_path
+			header_prefix = 'File'
+			label_fn = lambda k: k or '(unknown)'
+		elif mode == 'severity':
+			sort_key = lambda m: (self._severity_rank(m), self._display_path(m).lower(), self._tool_rank(m))
+			group_fn = self._severity_rank
+			header_prefix = 'Severity'
+			label_fn = lambda k: SEVERITY_LABELS.get(k, 'UNKNOWN')
+		else:
+			sort_key = lambda m: (self._tool_rank(m), self._display_path(m).lower(), self._severity_rank(m))
+			group_fn = self._tool_rank
+			header_prefix = 'Tool'
+			label_fn = lambda k: TOOL_LABELS[k]
+
+		sorted_messages = sorted(messages, key=sort_key)
 		lines = []
 
-		for file_path, file_messages in messages_by_file.items():
-			display_path = self._get_repo_relative_path(file_path).lstrip('/')
-
-			lines.append(f'\nFile: {display_path}\n')
-
-			for msg in file_messages:
+		for group_key, group_msgs in groupby(sorted_messages, key=group_fn):
+			lines.append(f'\n{header_prefix}: {label_fn(group_key)}\n')
+			for msg in group_msgs:
+				display_path = self._display_path(msg)
 				lines.append(self._format_message(msg, display_path))
 				lines.append('')
 
 		return '\n'.join(lines)
-
-	def _group_by_file(self, messages: List[Message]) -> dict:
-		grouped = {}
-		for msg in messages:
-			key = msg.abspath
-			if key not in grouped:
-				grouped[key] = []
-			grouped[key].append(msg)
-		return grouped
 
 	def _get_repo_relative_path(self, file_path: str) -> str:
 		if not self.pr or not self.pr.files_dir:
@@ -129,9 +160,10 @@ class PullRequestReportGenerator:
 
 
 class ReportGenerator:
-	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2):
+	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str | None = None):
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
+		self.sort_messages = sort_messages
 
 	def generate(self, results: list[tuple]) -> None:
 		groups: dict = {}
@@ -166,5 +198,6 @@ class ReportGenerator:
 					pr,
 					show_code_snippet=self.show_code_snippet,
 					snippet_context_lines=self.snippet_context_lines,
+					sort_messages=self.sort_messages,
 				)
 				print(pr_generator.generate(messages))

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -19,7 +19,7 @@ class PullRequestReportGenerator:
 		pr,
 		show_code_snippet: bool = True,
 		snippet_context_lines: int = 2,
-		sort_messages: str | None = None,
+		sort_messages: str = "files",
 	):
 		self.pr = pr
 		self.show_code_snippet = show_code_snippet
@@ -39,16 +39,8 @@ class PullRequestReportGenerator:
 	def generate(self, messages: List[Message]) -> str:
 		if not messages:
 			return 'No issues found.\n'
-
-		if self.sort_messages is None:
-			lines = []
-			for msg in messages:
-				lines.append(self._format_message(msg, self._display_path(msg)))
-				lines.append('')
-			return '\n'.join(lines)
-
+		
 		mode = self.sort_messages
-
 		if mode == 'files':
 			sort_key = lambda m: (self._display_path(m).lower(), self._tool_rank(m), self._severity_rank(m))
 			group_fn = self._display_path
@@ -160,7 +152,7 @@ class PullRequestReportGenerator:
 
 
 class ReportGenerator:
-	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str | None = None):
+	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str = "files"):
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
 		self.sort_messages = sort_messages

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -154,10 +154,16 @@ class PullRequestReportGenerator:
 
 
 class ReportGenerator:
-	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str = OPTION_SORT_MESSAGES_DEFAULT):
+	def __init__(self,
+		show_code_snippet: bool = True,
+		snippet_context_lines: int = 2,
+		sort_messages: str = OPTION_SORT_MESSAGES_DEFAULT,
+		first_separator: bool = False,
+	):
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
 		self.sort_messages = sort_messages
+		self.first_separator = first_separator
 
 	def generate(self, results: list[tuple]) -> None:
 		groups: dict = {}
@@ -171,7 +177,7 @@ class ReportGenerator:
 		first = True
 		for repo_url in sorted(groups.keys(), key=repo_sort_key):
 			for pr, messages in sorted(groups[repo_url], key=lambda x: x[0].number):
-				if not first:
+				if not first or self.first_separator:
 					print('\n====================================\n')
 				first = False
 
@@ -179,7 +185,7 @@ class ReportGenerator:
 				if pr.author_name:
 					author_display = f'{pr.author_username} ({pr.author_name})'
 				date_str = pr.created_at.strftime('%Y.%m.%d') if pr.created_at else 'N/A'
-				print('\nRepository: ', pr.repo_url)
+				print('Repository: ', pr.repo_url)
 				print('PR: ', pr.pr_url)
 				print('Author: ', author_display)
 				print('Date: ', date_str)

--- a/src/reports/report_generator.py
+++ b/src/reports/report_generator.py
@@ -8,6 +8,9 @@ from ..logger import warning
 
 TMP_PREFIX = re.compile(r'^/tmp/tmp[^/]+/')
 
+OPTION_SORT_MESSAGES_CHOICES = ['files', 'severity', 'tools']
+OPTION_SORT_MESSAGES_DEFAULT = 'files'
+
 TOOL_RANK = {'Pylint': 0, 'OCLint': 1, 'CustomRules': 2, 'Other': 3}
 TOOL_LABELS = {0: 'Pylint', 1: 'OCLint', 2: 'CustomRules', 3: 'Other'}
 SEVERITY_LABELS = {0: 'INFO', 1: 'REFACTOR', 2: 'CONVENTION', 3: 'WARNING', 4: 'ERROR', 5: 'FATAL'}
@@ -19,12 +22,12 @@ class PullRequestReportGenerator:
 		pr,
 		show_code_snippet: bool = True,
 		snippet_context_lines: int = 2,
-		sort_messages: str = "files",
+		sort_messages: str = OPTION_SORT_MESSAGES_DEFAULT,
 	):
 		self.pr = pr
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
-		self.sort_messages = sort_messages
+		self.sort_messages = sort_messages or OPTION_SORT_MESSAGES_DEFAULT
 
 	def _tool_rank(self, msg: Message) -> int:
 		return TOOL_RANK.get(msg.linter, TOOL_RANK['Other'])
@@ -39,14 +42,13 @@ class PullRequestReportGenerator:
 	def generate(self, messages: List[Message]) -> str:
 		if not messages:
 			return 'No issues found.\n'
-		
-		mode = self.sort_messages
-		if mode == 'files':
+
+		if self.sort_messages == 'files':
 			sort_key = lambda m: (self._display_path(m).lower(), self._tool_rank(m), self._severity_rank(m))
 			group_fn = self._display_path
 			header_prefix = 'File'
 			label_fn = lambda k: k or '(unknown)'
-		elif mode == 'severity':
+		elif self.sort_messages == 'severity':
 			sort_key = lambda m: (self._severity_rank(m), self._display_path(m).lower(), self._tool_rank(m))
 			group_fn = self._severity_rank
 			header_prefix = 'Severity'
@@ -152,7 +154,7 @@ class PullRequestReportGenerator:
 
 
 class ReportGenerator:
-	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str = "files"):
+	def __init__(self, show_code_snippet: bool = True, snippet_context_lines: int = 2, sort_messages: str = OPTION_SORT_MESSAGES_DEFAULT):
 		self.show_code_snippet = show_code_snippet
 		self.snippet_context_lines = snippet_context_lines
 		self.sort_messages = sort_messages


### PR DESCRIPTION
### Описание
Добавлена опция --sort-messages с вариантами: files (по умолчанию), severity, tools. 
files - сначала в алфавитном порядке по файлам, потом в порядке Pylint, OCLint, CustomRules, далее в порядке возрастания серьёзности. 
severity - cначала в порядке возрастания серьёзности, потом в алфавитном порядке по файлам, далее в порядке Pylint, OCLint, CustomRules, всё остальное.
tools - cначала в порядке Pylint, OCLint, CustomRules, всё остальное, потом в алфавитном порядке по файлам, далее в порядке возрастания серьёзности.

Имя файла рассматривается как относительный путь до файла.
В данном варианте сортируются определенным образом все переданные pr.


### Как тестировать
Можно запустить проверку данного pr:
```
docker run mse1h2026-helper https://github.com/GeorgiiPoliakov1/test/pull/1 --token <YOUR_TOKEN> --sort-messages severity
```
<!--
Вы также можете добавить следующие разделы:
### Мотивация
### Какое новое поведение?
### Как тестировать
### Будущие улучшения
-->
