### PR TITLE
Добавлен fallback-анализ с помощью Clang при поломке OCLint

### DIFF
--- a/.github/workflows/integration_functional_tests.yml
+++ b/.github/workflows/integration_functional_tests.yml
@@ -33,6 +33,8 @@ jobs:
             --token "${GITHUB_TOKEN}" \
             https://github.com/pasabanov/mse1h2026-helper-test/pull/1 > cpp_github.log 2>&1
 
+          cat cpp_github.log
+
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Exit code: $EXIT_CODE"
@@ -55,6 +57,8 @@ jobs:
             mse1h2026-helper:test \
             --token "${GITHUB_TOKEN}" \
             https://github.com/pasabanov/mse1h2026-helper-test/pull/2 > python_github.log 2>&1
+
+          cat python_github.log
 
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
@@ -79,6 +83,8 @@ jobs:
             --token "${FORGEJO_TOKEN}" \
             https://codeberg.org/pasabanov/mse1h2026-helper-test/pulls/1 > cpp_forgejo.log 2>&1
 
+          cat cpp_forgejo.log
+
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Exit code: $EXIT_CODE"
@@ -100,6 +106,8 @@ jobs:
             mse1h2026-helper:test \
             --token "${FORGEJO_TOKEN}" \
             https://codeberg.org/pasabanov/mse1h2026-helper-test/pulls/2 > python_forgejo.log 2>&1
+
+          cat python_forgejo.log
 
           EXIT_CODE=$?
           if [ $EXIT_CODE -ne 0 ]; then

--- a/.github/workflows/integration_functional_tests.yml
+++ b/.github/workflows/integration_functional_tests.yml
@@ -41,10 +41,10 @@ jobs:
             exit 1
           fi
 
-          grep -q "[OCLint]" cpp_github.log || (echo "Missing OCLint output" && exit 1)
-          grep -q "[CustomRules]" cpp_github.log || (echo "Missing CustomRules output" && exit 1)
-          grep -q "main.cpp" cpp_github.log || echo "No C++ files found"
-          grep -q "Traceback" cpp_github.log && (echo "Found Traceback" && exit 1) || true
+          grep -Fq "[OCLint]" cpp_github.log || (echo "Missing OCLint output" && exit 1)
+          # grep -Fq "[CustomRules]" cpp_github.log || (echo "Missing CustomRules output" && exit 1)
+          grep -Fq "main.cpp" cpp_github.log || echo "No C++ files found"
+          grep -Fq "Traceback" cpp_github.log && (echo "Found Traceback" && exit 1) || true
 
           echo "GitHub C++ PR passed"
 
@@ -66,10 +66,10 @@ jobs:
             exit 1
           fi
 
-          grep -q "[Pylint]" python_github.log || (echo "Missing Pylint output" && exit 1)
-          grep -q "[CustomRules]" python_github.log || (echo "Missing CustomRules output" && exit 1)
-          grep -q "\.py" python_github.log || echo "No Python files found"
-          grep -q "Traceback" python_github.log && (echo "Found Traceback" && exit 1) || true
+          grep -Fq "[Pylint]" python_github.log || (echo "Missing Pylint output" && exit 1)
+          grep -Fq "[CustomRules]" python_github.log || (echo "Missing CustomRules output" && exit 1)
+          grep -Fq "main.py" python_github.log || echo "No Python files found"
+          grep -Fq "Traceback" python_github.log && (echo "Found Traceback" && exit 1) || true
 
           echo "GitHub Python PR passed"
 
@@ -91,9 +91,10 @@ jobs:
             exit 1
           fi
 
-          grep -q "[OCLint]" cpp_forgejo.log || (echo "Missing OCLint output" && exit 1)
-          grep -q "[CustomRules]" cpp_forgejo.log || (echo "Missing CustomRules output" && exit 1)
-          grep -q "Traceback" cpp_forgejo.log && (echo "Found Traceback" && exit 1) || true
+          grep -Fq "[OCLint]" cpp_forgejo.log || (echo "Missing OCLint output" && exit 1)
+          # grep -Fq "[CustomRules]" cpp_forgejo.log || (echo "Missing CustomRules output" && exit 1)
+          grep -Fq "main.cpp" cpp_forgejo.log || echo "No C++ files found"
+          grep -Fq "Traceback" cpp_forgejo.log && (echo "Found Traceback" && exit 1) || true
 
           echo "Forgejo C++ PR passed"
 
@@ -115,8 +116,9 @@ jobs:
             exit 1
           fi
 
-          grep -q "[Pylint]" python_forgejo.log || (echo "Missing Pylint output" && exit 1)
-          grep -q "[CustomRules]" python_forgejo.log || (echo "Missing CustomRules output" && exit 1)
-          grep -q "Traceback" python_forgejo.log && (echo "Found Traceback" && exit 1) || true
+          grep -Fq "[Pylint]" python_forgejo.log || (echo "Missing Pylint output" && exit 1)
+          grep -Fq "[CustomRules]" python_forgejo.log || (echo "Missing CustomRules output" && exit 1)
+          grep -Fq "main.py" python_forgejo.log || echo "No Python files found"
+          grep -Fq "Traceback" python_forgejo.log && (echo "Found Traceback" && exit 1) || true
 
           echo "Forgejo Python PR passed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apt-get update && apt-get install -y \
 	python-is-python3 \
 	python3-pip \
 	wget \
-	clang-13 \
-	&& ln -sf /usr/bin/clang-13 /usr/bin/clang
+	clang-15
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY install_oclint.sh /tmp/install_oclint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
 	python-is-python3 \
 	python3-pip \
 	wget \
-	clang-14
+	clang-15
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY install_oclint.sh /tmp/install_oclint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
+	build-essential \
 	python-is-python3 \
 	python3-pip \
-	wget
+	wget \
+	clang-13 \
+	&& ln -sf /usr/bin/clang-13 /usr/bin/clang
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY install_oclint.sh /tmp/install_oclint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
 	python-is-python3 \
 	python3-pip \
 	wget \
-	clang-15
+	clang-14
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY install_oclint.sh /tmp/install_oclint.sh

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
 PYTHON_EXTENSIONS = ['.py']
+C_EXTENSIONS = ['.c']
 CPP_EXTENSIONS = ['.c', '.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP', '.h', '.hpp', '.hh', '.hxx', '.h++', '.H', '.HPP']
 SUPPORTED_EXTENSIONS = PYTHON_EXTENSIONS + CPP_EXTENSIONS

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 PYTHON_EXTENSIONS = ['.py']
 C_EXTENSIONS = ['.c']
-CPP_EXTENSIONS = ['.c', '.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP', '.h', '.hpp', '.hh', '.hxx', '.h++', '.H', '.HPP']
-SUPPORTED_EXTENSIONS = PYTHON_EXTENSIONS + CPP_EXTENSIONS
+CPP_EXTENSIONS = ['.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP', '.h', '.hpp', '.hh', '.hxx', '.h++', '.H', '.HPP']
+C_CPP_EXTENSIONS = C_EXTENSIONS + CPP_EXTENSIONS
+SUPPORTED_EXTENSIONS = PYTHON_EXTENSIONS + C_CPP_EXTENSIONS

--- a/src/linters/custom_rules/ast_cache.py
+++ b/src/linters/custom_rules/ast_cache.py
@@ -4,7 +4,7 @@ from typing import Optional, TypeAlias
 
 import clang.cindex
 
-from ...config import PYTHON_EXTENSIONS, CPP_EXTENSIONS
+from ...config import PYTHON_EXTENSIONS, C_CPP_EXTENSIONS
 
 AST: TypeAlias = ast.AST | clang.cindex.TranslationUnit
 
@@ -37,7 +37,7 @@ class ASTCache:
 					content = f.read()
 				tree = ast.parse(content, filename=file_path)
 
-			elif ext in CPP_EXTENSIONS:
+			elif ext in C_CPP_EXTENSIONS:
 				index = clang.cindex.Index.create()
 				tree = index.parse(file_path)
 

--- a/src/linters/custom_rules/goto_rule.py
+++ b/src/linters/custom_rules/goto_rule.py
@@ -6,7 +6,7 @@ from pylint.interfaces import UNDEFINED
 
 from .base import FileRule
 from .ast_cache import ASTCache
-from ...config import CPP_EXTENSIONS
+from ...config import C_CPP_EXTENSIONS
 from ...reports.message import Message, MessageLocation
 
 
@@ -19,7 +19,7 @@ class GotoRule(FileRule):
 		if not file_path:
 			return []
 
-		if PurePath(file_path).suffix not in CPP_EXTENSIONS:
+		if PurePath(file_path).suffix not in C_CPP_EXTENSIONS:
 			return []
 
 		tree = self.ast_cache.parse_file(file_path)

--- a/src/linters/custom_rules/require_rule.py
+++ b/src/linters/custom_rules/require_rule.py
@@ -7,7 +7,7 @@ from pylint.interfaces import UNDEFINED
 
 from .base import PRRule
 from .ast_cache import ASTCache
-from ...config import PYTHON_EXTENSIONS, CPP_EXTENSIONS
+from ...config import PYTHON_EXTENSIONS, C_CPP_EXTENSIONS
 from ...reports.message import Message, MessageLocation
 
 
@@ -25,7 +25,7 @@ class RequireRule(PRRule):
 
 		for file_path in pr.files:
 			ext = PurePath(file_path).suffix
-			if ext in CPP_EXTENSIONS:
+			if ext in C_CPP_EXTENSIONS:
 				tree = self.ast_cache.parse_file(file_path)
 				if tree is None:
 					continue

--- a/src/linters/factory.py
+++ b/src/linters/factory.py
@@ -1,13 +1,13 @@
 from .base import Linter
 from .pylint_runner import PylintWrapper
 from .oclint_runner import OCLintWrapper
-from ..config import PYTHON_EXTENSIONS, CPP_EXTENSIONS
+from ..config import PYTHON_EXTENSIONS, C_CPP_EXTENSIONS
 
 
 class LinterFactory:
 	_linters = {
 		**{ext: PylintWrapper() for ext in PYTHON_EXTENSIONS},
-		**{ext: OCLintWrapper() for ext in CPP_EXTENSIONS}
+		**{ext: OCLintWrapper() for ext in C_CPP_EXTENSIONS}
 	}
 
 	@classmethod

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -6,13 +6,12 @@ from typing import List, Optional, Tuple
 
 from pylint.interfaces import UNDEFINED
 
+from ..config import C_EXTENSIONS, CPP_EXTENSIONS
 from .base import Linter
 from ..reports.message import Message, MessageLocation
 
 C_STANDARD = '-std=c17'
 CPP_STANDARD = '-std=c++17'
-C_EXTENSIONS = {'.c'}
-CPP_EXTENSIONS = {'.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP'}
 
 
 class OCLintWrapper(Linter):

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -1,6 +1,7 @@
 import json
 import re
 import subprocess
+import sys
 from pathlib import Path, PurePath
 from typing import List, Optional, Tuple
 
@@ -12,6 +13,10 @@ from ..reports.message import Message, MessageLocation
 
 C_STANDARD = '-std=c17'
 CPP_STANDARD = '-std=c++17'
+CLANG_ERROR_PATTERN = re.compile(
+    r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
+    re.IGNORECASE | re.MULTILINE
+)
 
 
 class OCLintWrapper(Linter):
@@ -87,12 +92,8 @@ class OCLintWrapper(Linter):
 
 	def _parse_clang_output(self, source_file: Path, output: str) -> List[Message]:
 		messages = []
-		pattern = re.compile(
-			r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
-			re.IGNORECASE | re.MULTILINE
-		)
-
-		for match in pattern.finditer(output):
+		
+		for match in CLANG_ERROR_PATTERN.finditer(output):
 			_, line_no, level, msg = match.groups()
 			if level.lower() == 'warning':
 				continue
@@ -129,6 +130,12 @@ class OCLintWrapper(Linter):
 					return self._parse_oclint_violations(data, file_path)
 			except json.JSONDecodeError:
 				pass
+
+		print(
+            f"OCLint analysis failed for '{source_file.name}'. "
+            f"Falling back to Clang for syntax check.",
+            file=sys.stderr
+        )
 
 		clang_cmd = [
 			'clang', '-fsyntax-only', '-Wall', '-Wextra', '-ferror-limit=10',

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -16,6 +16,11 @@ CPP_EXTENSIONS = {'.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP'}
 
 
 class OCLintWrapper(Linter):
+	"""
+	Performs analysis with OCLint.
+	Fallbacks to analysis with Clang if OCLint crashes.
+	"""
+
 	@staticmethod
 	def _detect_standard(file_path: str) -> Tuple[List[str], List[str]]:
 		_ext = Path(file_path).suffix.lower()
@@ -87,12 +92,12 @@ class OCLintWrapper(Linter):
 			r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
 			re.IGNORECASE | re.MULTILINE
 		)
-		
+
 		for match in pattern.finditer(output):
 			_, line_no, level, msg = match.groups()
 			if level.lower() == 'warning':
 				continue
-				
+
 			messages.append(self._create_message(
 				file_path=str(source_file),
 				line=int(line_no),
@@ -130,7 +135,7 @@ class OCLintWrapper(Linter):
 			'clang', '-fsyntax-only', '-Wall', '-Wextra', '-ferror-limit=10',
 			*standards, *lang_flags, str(source_file),
 		]
-		
+
 		try:
 			clang_res = subprocess.run(clang_cmd, capture_output=True, text=True, timeout=30)
 		except Exception:

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -1,14 +1,60 @@
 import json
+import re
 import subprocess
-from pathlib import PurePath
+from pathlib import Path, PurePath
+from typing import List, Optional, Tuple
 
 from pylint.interfaces import UNDEFINED
 
 from .base import Linter
 from ..reports.message import Message, MessageLocation
 
+C_STANDARD = '-std=c17'
+CPP_STANDARD = '-std=c++17'
+C_EXTENSIONS = {'.c'}
+CPP_EXTENSIONS = {'.cpp', '.cc', '.cxx', '.c++', '.C', '.CPP'}
+
 
 class OCLintWrapper(Linter):
+	@staticmethod
+	def _detect_standard(file_path: str) -> Tuple[List[str], List[str]]:
+		_ext = Path(file_path).suffix.lower()
+		if _ext in C_EXTENSIONS:
+			return [C_STANDARD], []
+		if _ext in CPP_EXTENSIONS:
+			return [CPP_STANDARD], ['-x', 'c++']
+		return [CPP_STANDARD], ['-x', 'c++']
+
+	def _create_message(
+		self,
+		file_path: str,
+		line: int,
+		column: int,
+		msg: str,
+		msg_id: str,
+		symbol: str,
+		linter: str,
+		end_line: Optional[int] = None,
+		end_column: Optional[int] = None,
+	) -> Message:
+		return Message(
+			msg_id=msg_id,
+			symbol=symbol,
+			location=MessageLocation(
+				abspath=str(Path(file_path).resolve()),
+				path=str(file_path),
+				module=PurePath(file_path).stem,
+				obj='',
+				line=line,
+				column=column,
+				end_line=end_line,
+				end_column=end_column,
+			),
+			msg=msg,
+			confidence=UNDEFINED,
+			linter=linter,
+		)
+
 	def _msg_id_for_priority(self, priority: int) -> str:
 		# Pylint ожидает первую букву из своих типов: F/E/W/C/R/I
 		# Для OCLint удобно транслировать так:
@@ -18,78 +64,77 @@ class OCLintWrapper(Linter):
 			return 'WARNING'
 		return 'REFACTOR'
 
-	def run(self, file_path: str):
-		result = subprocess.run(
-			[
-				'oclint',
-				'-report-type', 'json',
-				file_path,
-				'--',
-				'-std=c++17',
-				'-Wall',
-				'-Wextra',
-				'-pedantic',
-			],
-			capture_output=True,
-			text=True,
+	def _parse_oclint_violations(self, data: dict, file_path: str) -> List[Message]:
+		messages = []
+		for v in data.get('violation', []):
+			priority = int(v.get('priority', 3) or 3)
+			messages.append(self._create_message(
+				file_path=file_path,
+				line=int(v.get('startLine', 1) or 1),
+				column=int(v.get('startColumn', 1) or 1),
+				msg=str(v.get('message') or v.get('rule') or ''),
+				msg_id=self._msg_id_for_priority(priority),
+				symbol=str(v.get('rule', '')).replace(' ', '_'),
+				linter='OCLint',
+				end_line=v.get('endLine'),
+				end_column=v.get('endColumn'),
+			))
+		return messages
+
+	def _parse_clang_output(self, source_file: Path, output: str) -> List[Message]:
+		messages = []
+		pattern = re.compile(
+			r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
+			re.IGNORECASE | re.MULTILINE
 		)
+		
+		for match in pattern.finditer(output):
+			_, line_no, level, msg = match.groups()
+			if level.lower() == 'warning':
+				continue
+				
+			messages.append(self._create_message(
+				file_path=str(source_file),
+				line=int(line_no),
+				column=0,
+				msg=msg.strip(),
+				msg_id='ERROR' if level.lower() in ('error', 'fatal error') else 'WARNING',
+				symbol='fatal-error' if level.lower() == 'fatal error' else 'syntax-error',
+				linter='OCLint',
+			))
+		return messages
 
-		if result.returncode not in (0, 1):
-			raise RuntimeError(
-				f'OCLint failed with code {result.returncode}:\n'
-				f'stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}'
-			)
+	def run(self, file_path: str) -> List[Message]:
+		source_file = Path(file_path).resolve()
+		standards, lang_flags = self._detect_standard(file_path)
 
-		raw = result.stdout.strip()
-		if not raw:
-			raise RuntimeError(
-				f'OCLint returned empty stdout.\n'
-				f'stderr:\n{result.stderr}'
-			)
+		oclint_cmd = [
+			'oclint', '-report-type', 'json', str(source_file), '--',
+			*lang_flags, *standards, '-Wall', '-Wextra',
+		]
 
 		try:
-			data = json.loads(raw)
-		except json.JSONDecodeError as e:
-			raise RuntimeError(
-				f'Failed to parse OCLint JSON: {e}\n'
-				f'raw stdout:\n{raw}\n\nstderr:\n{result.stderr}'
-			)
+			result = subprocess.run(oclint_cmd, capture_output=True, text=True, timeout=60)
+		except Exception:
+			result = None
 
-		violations = data.get('violation', [])
+		if result and result.stdout.strip():
+			try:
+				data = json.loads(result.stdout)
+				if data.get('summary', {}).get('numberOfFiles', 0) > 0:
+					return self._parse_oclint_violations(data, file_path)
+			except json.JSONDecodeError:
+				pass
 
-		messages = []
+		clang_cmd = [
+			'clang', '-fsyntax-only', '-Wall', '-Wextra', '-ferror-limit=10',
+			*standards, *lang_flags, str(source_file),
+		]
+		
+		try:
+			clang_res = subprocess.run(clang_cmd, capture_output=True, text=True, timeout=30)
+		except Exception:
+			return []
 
-		for v in violations:
-			path = v.get('path', file_path)
-			start_line = int(v.get('startLine', 0) or 0)
-			start_col = int(v.get('startColumn', 0) or 0)
-			end_line = v.get('endLine')
-			end_col = v.get('endColumn')
-
-			priority = int(v.get('priority', 3) or 3)
-			msg_id = self._msg_id_for_priority(priority)
-			symbol = str(v.get('rule', '')).replace(' ', '_')
-			msg_text = str(v.get('message') or v.get('rule') or '')
-
-			location = MessageLocation(
-				abspath=path,
-				path=path,
-				module=PurePath(path).stem,
-				obj='',
-				line=start_line,
-				column=start_col,
-				end_line=end_line,
-				end_column=end_col,
-			)
-
-			message = Message(
-				msg_id=msg_id,
-				symbol=symbol,
-				location=location,
-				msg=msg_text,
-				confidence=UNDEFINED,
-				linter='OCLint'
-			)
-			messages.append(message)
-
-		return messages
+		all_output = clang_res.stderr + '\n' + clang_res.stdout
+		return self._parse_clang_output(source_file, all_output)

--- a/src/linters/oclint_runner.py
+++ b/src/linters/oclint_runner.py
@@ -14,8 +14,8 @@ from ..reports.message import Message, MessageLocation
 C_STANDARD = '-std=c17'
 CPP_STANDARD = '-std=c++17'
 CLANG_ERROR_PATTERN = re.compile(
-    r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
-    re.IGNORECASE | re.MULTILINE
+	r'^(.+?):(\d+):(?:\d+)?:\s*(error|fatal error|warning):\s*(.+?)(?:\s*\[-W|\s*$)',
+	re.IGNORECASE | re.MULTILINE
 )
 
 
@@ -92,7 +92,7 @@ class OCLintWrapper(Linter):
 
 	def _parse_clang_output(self, source_file: Path, output: str) -> List[Message]:
 		messages = []
-		
+
 		for match in CLANG_ERROR_PATTERN.finditer(output):
 			_, line_no, level, msg = match.groups()
 			if level.lower() == 'warning':
@@ -132,10 +132,10 @@ class OCLintWrapper(Linter):
 				pass
 
 		print(
-            f"OCLint analysis failed for '{source_file.name}'. "
-            f"Falling back to Clang for syntax check.",
-            file=sys.stderr
-        )
+			f"OCLint analysis failed for '{source_file.name}'. "
+			f"Falling back to Clang for syntax check.",
+			file=sys.stderr
+		)
 
 		clang_cmd = [
 			'clang', '-fsyntax-only', '-Wall', '-Wextra', '-ferror-limit=10',


### PR DESCRIPTION
### Описание

Ранее `Oclint` ломался при серьезных ошибках, как отсутствие типа данных или отсутствие файлов импорта. При такое поломке не передавались никакие сообщения, что является какой-то недоработкой `Oclint`. Теперь при поломке `OcLint`, анализ будет производить напрямую `clang`, который при критических ошибках выдает детали этих ошибок. В `Dockerfile` добавлена установка `clang-13`. В файле `oclint_runner` внесена возможность обработки файла с помощью `clang`.

### Тестирование
Работа программы на PR преподавателя:
PR: https://github.com/moevm/grpc_server/pull/157
```bash
docker run mse1h2026-helper --token <> https://github.com/moevm/grpc_server/pull/157                                   
[13:16:14] Авторизация на GitHub выполнена
[13:16:17] Найден PR #157 в репозитории moevm/grpc_server
[13:16:21] Загружены файлы: types.h, filtr_packets.c, pars_packets.c, proc_packets.c, main.cpp, worker.cpp
[13:16:21] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/include/dpdk_filter/types.h (1/6)
[13:16:22] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/src/dpdk_filter/filtr_packets.c (2/6)[13:16:22] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/src/dpdk_filter/pars_packets.c (3/6)
[13:16:22] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/src/dpdk_filter/proc_packets.c (4/6)
[13:16:22] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/src/main.cpp (5/6)
[13:16:22] Обработка файла /tmp/pr_-8018579424660696740_1wz6nkrx/worker/src/worker.cpp (6/6)
PR:  https://github.com/moevm/grpc_server/pull/157

File: worker/include/dpdk_filter/types.h

[OCLint]
worker/include/dpdk_filter/types.h:4: ERROR: 'constants.h' file not found
https://github.com/moevm/grpc_server/blob/776132b9ac2d2c0bd80b62b7c427065c60b6f495/worker/include/dpdk_filter/types.h#L4

  Code:
          2 | #define TYPES_H
          3 | 
     >    4 | #include "constants.h"
          5 | #include <stdbool.h>
          6 | #include <stdint.h>


File: worker/src/dpdk_filter/filtr_packets.c

[OCLint]
worker/src/dpdk_filter/filtr_packets.c:1: ERROR: 'filtr_packets.h' file not found
https://github.com/moevm/grpc_server/blob/776132b9ac2d2c0bd80b62b7c427065c60b6f495/worker/src/dpdk_filter/filtr_packets.c#L1

  Code:
     >    1 | #include "filtr_packets.h"
          2 | #include "pars_packets.h"
          3 | 
...
```

PR: https://github.com/moevm/grpc_server/pull/159
```bash
docker run mse1h2026-helper --token <> https://github.com/moevm/grpc_server/pull/159
[13:17:27] Авторизация на GitHub выполнена
[13:17:29] Найден PR #159 в репозитории moevm/grpc_server
[13:17:31] Загружены файлы: filtr_packets.c
[13:17:31] Обработка файла /tmp/pr_-4096162007047124832_6unagqjc/worker/src/dpdk_filter/filtr_packets.c (1/1)PR:  https://github.com/moevm/grpc_server/pull/159

File: worker/src/dpdk_filter/filtr_packets.c

[OCLint]
worker/src/dpdk_filter/filtr_packets.c:1: ERROR: 'filtr_packets.h' file not found
https://github.com/moevm/grpc_server/blob/2afcfc3644788b503d87d12176d1a401f47712f0/worker/src/dpdk_filter/filtr_packets.c#L1

  Code:
     >    1 | #include "filtr_packets.h"
          2 | #include "pars_packets.h"
          3 | 
```
У данного варианта есть нерешенный недостаток:
При обработке данного [PR](https://github.com/grebenshichovartem/bug/pull/5) анализ ошибок двоится, так как сначала происходит обработка файла `main.cpp`, в которую включен файл `types.h`, из-за этого происходит переход в заголовочник и уже обрабатывается он и ошибки выдаются про него, но в рамках обработки файла `main.cpp`. После этого идет отельная обработка файла `types.h`, в которой выдаются ранее описанные ошибки.
```bash
docker run mse1h2026-helper --token <> https://github.com/grebenshichovartem/bug/pull/5
[13:20:01] Авторизация на GitHub выполнена
[13:20:04] Найден PR #5 в репозитории grebenshichovartem/bug
[13:20:05] Загружены файлы: main.cpp, types.h
[13:20:05] Обработка файла /tmp/pr_9025836434141980456_kjw6dzoa/src/main.cpp (1/2)
[13:20:06] Обработка файла /tmp/pr_9025836434141980456_kjw6dzoa/src/types.h (2/2)
PR:  https://github.com/grebenshichovartem/bug/pull/5

File: src/main.cpp

[OCLint]
src/main.cpp:3: ERROR: unknown type name 'Rgb'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/main.cpp#L3

  Code:
          1 | #include <cstdlib>
          2 | #include "types.h"
     >    3 | 
          4 | 
          5 | int main(int argc, char **argv) {

[OCLint]
src/main.cpp:3: ERROR: unknown type name 'BitmapFileHeader'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/main.cpp#L3

  Code:
          1 | #include <cstdlib>
          2 | #include "types.h"
     >    3 | 
          4 | 
          5 | int main(int argc, char **argv) {

[OCLint]
src/main.cpp:3: ERROR: unknown type name 'BitmapInfoHeader'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/main.cpp#L3

  Code:
          1 | #include <cstdlib>
          2 | #include "types.h"
     >    3 | 
          4 | 
          5 | int main(int argc, char **argv) {


File: src/types.h

[OCLint]
src/types.h:3: ERROR: unknown type name 'Rgb'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/types.h#L3

  Code:
          1 | #pragma once
          2 | 
     >    3 | Rgb** read_bmp(char* file_name, BitmapFileHeader* bmfh, BitmapInfoHeader* bmif);
          4 | 
          5 | const bool CT = true;

[OCLint]
src/types.h:3: ERROR: unknown type name 'BitmapFileHeader'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/types.h#L3

  Code:
          1 | #pragma once
          2 | 
     >    3 | Rgb** read_bmp(char* file_name, BitmapFileHeader* bmfh, BitmapInfoHeader* bmif);
          4 | 
          5 | const bool CT = true;

[OCLint]
src/types.h:3: ERROR: unknown type name 'BitmapInfoHeader'
https://github.com/grebenshichovartem/bug/blob/b2f9b48651b44f87ba98de5e8f85c0d43d083eec/src/types.h#L3

  Code:
          1 | #pragma once
          2 | 
     >    3 | Rgb** read_bmp(char* file_name, BitmapFileHeader* bmfh, BitmapInfoHeader* bmif);
          4 | 
          5 | const bool CT = true;
```

