### PR TITLE
Зафиксированы версии apt-пакетов в Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
-	build-essential \
-	python-is-python3 \
-	python3-pip \
-	wget \
-	clang-15
+	build-essential=12.9ubuntu3 \
+	python-is-python3=3.9.2-2 \
+	python3-pip=22.0.2+dfsg-1ubuntu0.7 \
+	wget=1.21.2-2ubuntu1.1 \
+	clang-15=1:15.0.7-0ubuntu0.22.04.3
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY install_oclint.sh /tmp/install_oclint.sh


### PR DESCRIPTION
Версии пакетов получены с помощью команды:
```
# apt-cache policy build-essential python-is-python3 python3-pip wget clang-15
build-essential:
  Installed: (none)
  Candidate: 12.9ubuntu3
  Version table:
     12.9ubuntu3 500
        500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
python-is-python3:
  Installed: (none)
  Candidate: 3.9.2-2
  Version table:
     3.9.2-2 500
        500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
python3-pip:
  Installed: (none)
  Candidate: 22.0.2+dfsg-1ubuntu0.7
  Version table:
     22.0.2+dfsg-1ubuntu0.7 500
        500 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages
        500 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages
     22.0.2+dfsg-1 500
        500 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
wget:
  Installed: (none)
  Candidate: 1.21.2-2ubuntu1.1
  Version table:
     1.21.2-2ubuntu1.1 500
        500 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages
     1.21.2-2ubuntu1 500
        500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
clang-15:
  Installed: (none)
  Candidate: 1:15.0.7-0ubuntu0.22.04.3
  Version table:
     1:15.0.7-0ubuntu0.22.04.3 500
        500 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages
```