### PR TITLE
Зафиксированы версии пакетов в Dockerfile, обновлён README

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apt update
-          apt install -y python3 python3-pip python3-venv curl
+          apt-get update
+          apt-get install -y python3 python3-pip python3-venv curl
 
       - name: Install OCLint
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y software-properties-common curl \
+RUN apt-get update && apt-get install -y \
+	software-properties-common=0.99.22.9 \
+	curl=7.81.0-1ubuntu1.24 \
 	&& add-apt-repository -y ppa:deadsnakes/ppa \
-	&& apt install -y \
-	python3.12 python3.12-venv \
-	git clang-15 \
-	build-essential cmake meson ninja-build \
-	libssl-dev libnuma-dev pkg-config libcurl4-openssl-dev \
-	libbpf-dev m4 libpcap-dev libsqlite3-dev \
-	protobuf-compiler libprotobuf-dev \
-	libdpdk-dev \
+	&& apt-get install -y \
+	python3.12=3.12.13-1+jammy1 \
+	python3.12-venv=3.12.13-1+jammy1 \
+	git=1:2.34.1-1ubuntu1.17 \
+	clang-15=1:15.0.7-0ubuntu0.22.04.3 \
+	build-essential=12.9ubuntu3 \
+	cmake=3.22.1-1ubuntu1.22.04.2 \
+	meson=0.61.2-1 \
+	ninja-build=1.10.1-1 \
+	libssl-dev=3.0.2-0ubuntu1.23 \
+	libnuma-dev=2.0.14-3ubuntu2 \
+	pkg-config=0.29.2-1ubuntu3 \
+	libcurl4-openssl-dev=7.81.0-1ubuntu1.24 \
+	libbpf-dev=1:0.5.0-1ubuntu22.04.1 \
+	m4=1.4.18-5ubuntu2 \
+	libpcap-dev=1.10.1-4build1 \
+	libsqlite3-dev=3.37.2-2ubuntu0.5 \
+	protobuf-compiler=3.12.4-1ubuntu7.22.04.6 \
+	libprotobuf-dev=3.12.4-1ubuntu7.22.04.6 \
+	libdpdk-dev=21.11.9-0ubuntu0.22.04.2 \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN python3.12 -m ensurepip --upgrade && \
-	python3.12 -m pip install --upgrade pip setuptools wheel && \
+	python3.12 -m pip install --no-cache-dir pip==26.1.1 setuptools==82.0.1 wheel==0.47.0 && \
 	update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
 	update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
 
 COPY install_oclint.sh /tmp/install_oclint.sh
 RUN chmod +x /tmp/install_oclint.sh && /tmp/install_oclint.sh
-
-RUN python3 -m pip install --no-cache-dir pyelftools
 
 RUN curl -sL https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.2.4.tar.gz | tar -xz \
 	&& mkdir -p /usr/local/include/prometheus/detail \

--- a/README.md
+++ b/README.md
@@ -127,3 +127,52 @@ DPDK-заголовки также зависят от:
 | Заголовок | Пакет | Назначение |
 |-----------|-------|------------|
 | `<sqlite3.h>` | libsqlite3-dev | SQLite — работа с базами данных |
+
+---
+
+## Воспроизводимая сборка
+
+Все пакеты в Dockerfile зафиксированы до конкретных версий:
+
+### Системные пакеты (APT)
+
+| Пакет | Версия | Репозиторий |
+|-------|--------|-------------|
+| `software-properties-common` | `0.99.22.9` | jammy-updates |
+| `curl` | `7.81.0-1ubuntu1.24` | jammy-security |
+| `python3.12` | `3.12.13-1+jammy1` | deadsnakes PPA |
+| `python3.12-venv` | `3.12.13-1+jammy1` | deadsnakes PPA |
+| `git` | `1:2.34.1-1ubuntu1.17` | jammy-security |
+| `clang-15` | `1:15.0.7-0ubuntu0.22.04.3` | jammy-security |
+| `build-essential` | `12.9ubuntu3` | jammy |
+| `cmake` | `3.22.1-1ubuntu1.22.04.2` | jammy-updates |
+| `meson` | `0.61.2-1` | jammy |
+| `ninja-build` | `1.10.1-1` | jammy |
+| `libssl-dev` | `3.0.2-0ubuntu1.23` | jammy-security |
+| `libnuma-dev` | `2.0.14-3ubuntu2` | jammy |
+| `pkg-config` | `0.29.2-1ubuntu3` | jammy |
+| `libcurl4-openssl-dev` | `7.81.0-1ubuntu1.24` | jammy-security |
+| `libbpf-dev` | `1:0.5.0-1ubuntu22.04.1` | jammy-security |
+| `m4` | `1.4.18-5ubuntu2` | jammy |
+| `libpcap-dev` | `1.10.1-4build1` | jammy |
+| `libsqlite3-dev` | `3.37.2-2ubuntu0.5` | jammy-security |
+| `protobuf-compiler` | `3.12.4-1ubuntu7.22.04.6` | jammy-security |
+| `libprotobuf-dev` | `3.12.4-1ubuntu7.22.04.6` | jammy-security |
+| `libdpdk-dev` | `21.11.9-0ubuntu0.22.04.2` | jammy-security |
+
+### Инструменты сборки Python
+
+| Пакет | Версия |
+|-------|--------|
+| `pip` | `26.1.1` |
+| `setuptools` | `82.0.1` |
+| `wheel` | `0.47.0` |
+
+### Python-зависимости (requirements.txt)
+
+| Пакет | Версия |
+|-------|--------|
+| `pyelftools` | `0.32` |
+| `pylint` | `4.0.5` |
+| `PyGithub` | `2.8.1` |
+| `libclang` | `18.1.1` |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyelftools==0.32
 pylint==4.0.5
 PyGithub==2.8.1
 libclang==18.1.1

--- a/src/main.py
+++ b/src/main.py
@@ -118,7 +118,7 @@ def main():
 	parser.add_argument('--pylint', help='Параметры для линтера Pylint')
 	parser.add_argument('--oclint', help='Параметры для линтера OCLint')
 	parser.add_argument('--oclint-include', action='append', dest='oclint_include', default=[], help='Путь для поиска include файлов (можно указать несколько раз)')
-	parser.add_argument('--install-packages', action='append', dest='install_packages', default=[], help='Установка системных пакетов (apt install) перед анализом')
+	parser.add_argument('--install-packages', action='append', dest='install_packages', default=[], help='Установка системных пакетов (apt-get install) перед анализом')
 	parser.add_argument('--repo', help='URL репозитория для анализа PR по номерам')
 	parser.add_argument('--pr-range', help='Диапазон номеров PR (например, 1-6)')
 	parser.add_argument('--pr-include', help='Список номеров PR для включения (например, 6,42)')
@@ -156,11 +156,11 @@ def main():
 		if args.install_packages:
 			info(f'Установка пакетов: {", ".join(args.install_packages)}')
 			subprocess.run(
-				['apt', 'update'],
+				['apt-get', 'update'],
 				check=True, capture_output=True
 			)
 			subprocess.run(
-				['apt', 'install', '-y', *args.install_packages],
+				['apt-get', 'install', '-y', *args.install_packages],
 				check=True, capture_output=True
 			)
 		for rule_param in args.rule_params:


### PR DESCRIPTION
### Описание

Для всех пакетов установлены версии:

#### Системные пакеты (APT)

| Пакет | Версия | Репозиторий |
|-------|--------|-------------|
| `software-properties-common` | `0.99.22.9` | jammy-updates |
| `curl` | `7.81.0-1ubuntu1.24` | jammy-security |
| `python3.12` | `3.12.13-1+jammy1` | deadsnakes PPA |
| `python3.12-venv` | `3.12.13-1+jammy1` | deadsnakes PPA |
| `git` | `1:2.34.1-1ubuntu1.17` | jammy-security |
| `clang-15` | `1:15.0.7-0ubuntu0.22.04.3` | jammy-security |
| `build-essential` | `12.9ubuntu3` | jammy |
| `cmake` | `3.22.1-1ubuntu1.22.04.2` | jammy-updates |
| `meson` | `0.61.2-1` | jammy |
| `ninja-build` | `1.10.1-1` | jammy |
| `libssl-dev` | `3.0.2-0ubuntu1.23` | jammy-security |
| `libnuma-dev` | `2.0.14-3ubuntu2` | jammy |
| `pkg-config` | `0.29.2-1ubuntu3` | jammy |
| `libcurl4-openssl-dev` | `7.81.0-1ubuntu1.24` | jammy-security |
| `libbpf-dev` | `1:0.5.0-1ubuntu22.04.1` | jammy-security |
| `m4` | `1.4.18-5ubuntu2` | jammy |
| `libpcap-dev` | `1.10.1-4build1` | jammy |
| `libsqlite3-dev` | `3.37.2-2ubuntu0.5` | jammy-security |
| `protobuf-compiler` | `3.12.4-1ubuntu7.22.04.6` | jammy-security |
| `libprotobuf-dev` | `3.12.4-1ubuntu7.22.04.6` | jammy-security |
| `libdpdk-dev` | `21.11.9-0ubuntu0.22.04.2` | jammy-security |

#### Инструменты сборки Python

| Пакет | Версия |
|-------|--------|
| `pip` | `26.1.1` |
| `setuptools` | `82.0.1` |
| `wheel` | `0.47.0` |

#### Python-зависимости (requirements.txt)

| Пакет | Версия |
|-------|--------|
| `pyelftools` | `0.32` |
| `pylint` | `4.0.5` |
| `PyGithub` | `2.8.1` |
| `libclang` | `18.1.1` |